### PR TITLE
fix(transcription): stop losing the tail of long recordings (2026.6.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2026.6.4] - 2026-06-05
+
+### Fixed
+
+- Recordings longer than about fifteen seconds no longer lose the end of the
+  transcription (often the final sentence). The Parakeet (FluidAudio) backend
+  decodes audio in fixed fifteen-second windows and stitches the pieces back
+  together; the tail could be dropped where those pieces were merged. Two things
+  caused it together: the bundled FluidAudio engine (0.10.0) had a faulty merge,
+  and Thoth was boosting the recording's volume before transcribing, which moved
+  the window boundaries onto speech and made the drop worse. Upgraded FluidAudio
+  to 0.15.0 (better merging) and stopped the pre-transcription volume boost,
+  which made no measurable difference to accuracy on quiet recordings. Verified
+  end to end through the app on recordings from fifteen seconds to nearly three
+  minutes, which now transcribe in full.
+
 ## [2026.6.3] - 2026-06-02
 
 A Linux/Wayland readiness pass. The audit behind it asked, for every OS-touching

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thoth-tauri",
-  "version": "2026.6.3",
+  "version": "2026.6.4",
   "private": true,
   "description": "Privacy-first, offline-capable voice transcription application",
   "type": "module",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thoth"
-version = "2026.6.3"
+version = "2026.6.4"
 description = "Privacy-first, offline-capable voice transcription application"
 authors = ["poodle64"]
 license = "MIT"
@@ -41,7 +41,7 @@ symphonia = { version = "0.5", features = ["mp3", "aac", "ogg", "vorbis", "flac"
 sherpa-rs = { version = "0.6", features = ["static", "download-binaries"], optional = true }
 # fluidaudio-rs: Apple Neural Engine backend via CoreML (macOS-only, Apple Silicon)
 # Forked with platform guards: compiles as no-op on Linux/Windows
-fluidaudio-rs = { git = "https://github.com/poodle64/fluidaudio-rs", rev = "97aaf88", optional = true }
+fluidaudio-rs = { git = "https://github.com/poodle64/fluidaudio-rs", rev = "62e756a", optional = true }
 
 # AI Enhancement and Model Downloads
 reqwest = { version = "0.12", features = ["json", "stream"] }

--- a/src-tauri/src/transcription/fluidaudio.rs
+++ b/src-tauri/src/transcription/fluidaudio.rs
@@ -90,46 +90,17 @@ impl TranscriptionService {
     }
 }
 
-/// Compute the normalisation gain for a clip given its RMS and peak amplitude.
+/// Pad a WAV file with leading and trailing silence, writing a temporary copy.
 ///
-/// The goal is to lift quiet recordings (e.g. from a lapel mic with overall RMS
-/// ~0.01) so the soft trailing words clear the TDT decoder's blank threshold,
-/// without clipping loud recordings or amplifying pure silence.
+/// The padding gives the TDT decoder run-in and run-out room around the speech:
+/// - 500 ms of leading silence (lets the model initialise before the first word).
+/// - 750 ms of trailing silence (lets it finalise after the last word).
 ///
-/// Rules:
-/// - Target RMS is 0.05; gain = target / rms (or 1.0 when rms is below noise floor).
-/// - Cap gain so peak * gain ≤ 0.95 (never clip).
-/// - Never attenuate: loud recordings get gain = 1.0 (only boost, never reduce).
-pub(crate) fn normalisation_gain(rms: f32, peak: f32) -> f32 {
-    const TARGET_RMS: f32 = 0.05;
-    const NOISE_FLOOR: f32 = 1e-6;
-    const MAX_PEAK: f32 = 0.95;
-
-    let mut gain = if rms > NOISE_FLOOR {
-        TARGET_RMS / rms
-    } else {
-        // Pure silence — don't amplify noise
-        1.0
-    };
-
-    // Cap so we don't clip
-    if peak > NOISE_FLOOR {
-        gain = gain.min(MAX_PEAK / peak);
-    }
-
-    // Only boost; never attenuate a recording that is already loud enough
-    gain.max(1.0)
-}
-
-/// Pad a WAV file with leading silence and low-level trailing dither, writing a
-/// temporary copy.  The original audio is RMS-normalised before writing so that
-/// soft trailing words (common on lapel mics) clear the TDT decoder's blank
-/// threshold instead of triggering its early-exit.
-///
-/// Padding:
-/// - 500 ms of hard-zero leading silence (gives the model time to initialise).
-/// - 0.75 s of low-level dither trailing (avoids a run of consecutive blanks that
-///   fires the decoder's early-exit before it emits the final words).
+/// The audio itself is copied through unchanged. An earlier version RMS-normalised
+/// it (to lift quiet lapel-mic recordings), but with FluidAudio 0.15 that gain
+/// shifted the silence-aligned chunk boundaries and caused the merge to drop the
+/// tail of recordings longer than ~15 s; removing it restores the full transcript
+/// with no measurable accuracy loss on quiet audio.
 ///
 /// Returns `Ok(Some(path))` with the padded temp file, or `Ok(None)` if the
 /// original file couldn't be read (in which case FluidAudio gets the original).
@@ -151,83 +122,40 @@ fn pad_with_silence(audio_path: &Path) -> Result<Option<PathBuf>> {
         audio_path.display()
     );
     let sample_rate = spec.sample_rate;
+    let channels = spec.channels as usize;
     let leading_samples = sample_rate as usize / 2; // 500 ms
-    let trailing_samples = sample_rate as usize * 3 / 4; // 0.75 s
-
-    // Collect all original samples as f32 in [-1.0, 1.0] so we can compute
-    // statistics for normalisation before writing.  We must collect first
-    // because `into_samples()` consumes the reader.
-    let samples_f32: Vec<f32> = match spec.sample_format {
-        hound::SampleFormat::Int => reader
-            .into_samples::<i16>()
-            .filter_map(|s| s.ok())
-            .map(|s| s as f32 / 32768.0)
-            .collect(),
-        hound::SampleFormat::Float => reader
-            .into_samples::<f32>()
-            .filter_map(|s| s.ok())
-            .collect(),
-    };
-
-    // RMS and peak over all collected samples
-    let rms = if samples_f32.is_empty() {
-        0.0
-    } else {
-        let mean_sq = samples_f32.iter().map(|&s| s * s).sum::<f32>() / samples_f32.len() as f32;
-        mean_sq.sqrt()
-    };
-    let peak = samples_f32.iter().map(|s| s.abs()).fold(0.0f32, f32::max);
-
-    let gain = normalisation_gain(rms, peak);
-    tracing::info!(
-        "FluidAudio normalise: rms={:.4} peak={:.4} gain={:.2}x",
-        rms,
-        peak,
-        gain
-    );
+    let trailing_samples = sample_rate as usize * 3 / 4; // 750 ms
 
     // Build temp path next to the original
     let tmp_path = audio_path.with_extension("padded.wav");
 
     let mut writer = hound::WavWriter::create(&tmp_path, spec)?;
 
-    // Cheap deterministic dither: sine-derived so it's non-repeating over short
-    // windows but totally reproducible.  Amplitude 0.001 is far below the speech
-    // floor yet enough to keep the decoder out of its consecutive-blank path.
-    let dither_f32 = |i: usize| -> f32 { (i as f32 * 0.000_123_f32).sin() * 0.001 };
-
-    let channels = spec.channels as usize;
-
+    // Copy the original audio through unchanged, wrapped in leading and trailing
+    // silence. No gain or dither is applied: FluidAudio 0.15 handles quiet audio
+    // directly, and altering the level shifts its silence-aligned chunk
+    // boundaries (which truncated the tail of long recordings).
     match spec.sample_format {
         hound::SampleFormat::Int => {
-            // Leading hard-zero silence
             for _ in 0..leading_samples * channels {
                 writer.write_sample(0i16)?;
             }
-            // Normalised original audio
-            for &s in &samples_f32 {
-                let out = (s * gain).clamp(-1.0, 1.0);
-                writer.write_sample((out * 32767.0).round() as i16)?;
+            for s in reader.into_samples::<i16>() {
+                writer.write_sample(s?)?;
             }
-            // Trailing low-level dither
-            for i in 0..trailing_samples * channels {
-                let out = dither_f32(i);
-                writer.write_sample((out * 32767.0).round() as i16)?;
+            for _ in 0..trailing_samples * channels {
+                writer.write_sample(0i16)?;
             }
         }
         hound::SampleFormat::Float => {
-            // Leading hard-zero silence
             for _ in 0..leading_samples * channels {
                 writer.write_sample(0.0f32)?;
             }
-            // Normalised original audio
-            for &s in &samples_f32 {
-                let out = (s * gain).clamp(-1.0, 1.0);
-                writer.write_sample(out)?;
+            for s in reader.into_samples::<f32>() {
+                writer.write_sample(s?)?;
             }
-            // Trailing low-level dither
-            for i in 0..trailing_samples * channels {
-                writer.write_sample(dither_f32(i))?;
+            for _ in 0..trailing_samples * channels {
+                writer.write_sample(0.0f32)?;
             }
         }
     }
@@ -235,7 +163,7 @@ fn pad_with_silence(audio_path: &Path) -> Result<Option<PathBuf>> {
     writer.finalize()?;
 
     tracing::info!(
-        "Padded WAV with {:.1}s leading silence + {:.1}s trailing dither: {}",
+        "Padded WAV with {:.1}s leading + {:.1}s trailing silence: {}",
         leading_samples as f32 / sample_rate as f32,
         trailing_samples as f32 / sample_rate as f32,
         tmp_path.display()
@@ -332,46 +260,5 @@ mod tests {
             Ok(_service) => println!("FluidAudio service created successfully"),
             Err(e) => println!("FluidAudio service creation failed: {}", e),
         }
-    }
-
-    // --- normalisation_gain unit tests ---
-
-    /// DJI MIC MINI real-world fixture: rms=0.011, peak=0.082.
-    /// target_rms / rms = 0.05 / 0.011 ≈ 4.545; peak cap = 0.95 / 0.082 ≈ 11.59.
-    /// Peak cap does not bind; max(1.0) does not bind.  Expected gain ≈ 4.545.
-    #[test]
-    fn test_gain_typical_quiet_clip() {
-        let gain = normalisation_gain(0.011, 0.082);
-        assert!(
-            (gain - 4.545).abs() < 0.01,
-            "expected ~4.545, got {gain:.4}"
-        );
-    }
-
-    /// Pure silence: rms below noise floor → gain = 1.0 (no amplification).
-    #[test]
-    fn test_gain_pure_silence() {
-        let gain = normalisation_gain(0.0, 0.0);
-        assert_eq!(gain, 1.0, "silence should return gain 1.0");
-    }
-
-    /// Loud clip: rms=0.1, peak=0.9.  target/rms = 0.5, which is below 1.0,
-    /// so max(1.0) applies → gain = 1.0 (never attenuate).
-    #[test]
-    fn test_gain_loud_clip_not_attenuated() {
-        let gain = normalisation_gain(0.1, 0.9);
-        assert_eq!(gain, 1.0, "loud clip should not be attenuated");
-    }
-
-    /// Peak-cap case: rms=0.001, peak=0.5.
-    /// target/rms = 0.05 / 0.001 = 50; peak cap = 0.95 / 0.5 = 1.9.
-    /// Peak cap binds → gain = 1.9; max(1.0) does not further reduce it.
-    #[test]
-    fn test_gain_peak_cap_binds() {
-        let gain = normalisation_gain(0.001, 0.5);
-        assert!(
-            (gain - 1.9).abs() < 0.001,
-            "expected peak-capped gain ~1.9, got {gain:.4}"
-        );
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Thoth",
-  "version": "2026.6.3",
+  "version": "2026.6.4",
   "identifier": "com.poodle64.thoth",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Recordings longer than ~15s lost the end of the transcription — often the final sentence. Root-caused to **two compounding bugs** in the Parakeet/FluidAudio path (the default backend), fixed together and verified end-to-end through the running app.

This is **not** the historic #46 (that was the Whisper ring-buffer; Parakeet is the default now).

## Root cause

FluidAudio decodes audio in fixed 15-second windows and merges the pieces. The tail was dropped at a merge boundary because:

1. **FluidAudio 0.10.0's chunk-merge** dropped tail tokens from the final window.
2. **`pad_with_silence` RMS-normalised** the audio before transcribing (up to ~10× gain on quiet lapel-mic input). Under 0.15's *silence-aligned* chunking, that gain shifted window boundaries onto speech and **re-triggered the drop even after the upgrade** — which is why the library bump alone wasn't enough.

## Fix

- Upgrade the `fluidaudio-rs` fork to **FluidAudio 0.15.0** (fork `main`, rev `62e756a`); adapts the Swift bridge to the 0.15 actor API (`AsrManager(models:)`, `transcribe(_, decoderState:)`, a `runBlocking` helper for the sync C FFI under Swift 6 strict concurrency).
- **Remove the pre-transcription normalisation** (and the trailing dither that propped it up) from `pad_with_silence`; it now pads with plain silence. A/B on a quiet recording showed no accuracy difference (98.9% vs 99.3% confidence). Removes the now-unused `normalisation_gain` and its tests.
- Bump to **2026.6.4**.

## Verification

Tested **through the running app** (not just a harness):

| Recording | Before | After |
|---|---|---|
| 17.09s (the original report) | cut at "...I just said" | full: "...off out of your mind." ✓ |
| 169s (~12 chunks) | — | full, coherent end-to-end ✓ |

Also confirmed full transcripts on 22s and 31s recordings, and no accuracy regression on a quiet (rms 0.005) recording.

CI gate (added in #70) runs clippy + tests on Linux and macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)