### PR TITLE
feat: Insights dashboard (#90) + opt-in Loki observability export

### DIFF
--- a/scripts/loki_backfill.py
+++ b/scripts/loki_backfill.py
@@ -14,10 +14,20 @@ Timestamps: the log changed format partway through its life, so both are
 parsed — early ``2026-02-16T03:07:24.701243Z`` (UTC) and later
 ``2026-06-22 09:40:23.914`` (local). Both convert to epoch-nanoseconds.
 
+Local-format timestamps (``2026-06-22 09:40:23.914``) are parsed as naive
+datetimes and interpreted in the **running machine's local timezone**. For
+accurate results, run this script on the same host that produced the logs, or
+set the ``TZ`` environment variable to match the log-producing host's timezone
+before running.
+
 Loki ingest: pushes oldest->newest per stream (Loki enforces a per-stream
 out-of-order window). The file is already chronological, so file order is
 preserved per stream. Relax ``reject_old_samples_max_age`` on the Loki
 instance before running a months-old backfill.
+
+IMPORTANT — no idempotency: re-running this script pushes duplicate entries
+into Loki. Clear the target Loki stream before re-running, or use ``--dry-run``
+to preview without pushing.
 
 Usage:
     # preview what would ship — needs no endpoint, sends nothing
@@ -54,17 +64,28 @@ LOCAL_RE = re.compile(
     r"(?P<level>TRACE|DEBUG|INFO|WARN|ERROR)\s+(?P<rest>.*)$"
 )
 
-# Hard DENY: the verbatim-transcript marker. Any line containing this is
-# dropped regardless of level. This is the structural privacy guarantee.
-TRANSCRIPT_MARKERS = ("characters: '", 'characters: "')
+# Hard DENY: any line containing one of these substrings is dropped regardless
+# of level. This is the structural privacy guarantee.
+#
+# Covered patterns (verified against src-tauri/src/transcription/):
+#   "Transcribed N characters: '<text>'"   — characters: '  / characters: "
+#   "Transcription result: '<text>'"       — whisper.rs:228, parakeet.rs:188
+TRANSCRIPT_MARKERS = (
+    "characters: '",
+    'characters: "',
+    "Transcription result:",
+)
 
 # ALLOW-LIST: substrings of valuable, content-free observability/performance
 # events. WARN/ERROR lines are allowed wholesale (minus the DENY net) because
 # operational failures are the point of the export.
+#
+# Verified against actual format strings in src-tauri/src/transcription/:
+#   whisper.rs / parakeet.rs: "Transcribed {:.2}s audio in {:.2}s (RTF: {:.3})"
+#   fluidaudio.rs:            "FluidAudio transcript: {} chars, {} words from {} segment(s) in {:.3}s"
 ALLOW_SUBSTRINGS = (
-    "Transcription took",
-    "transcribed",  # "FluidAudio transcribed Ns audio in Ns (RTFx: N)" — speed factor
-    "RTFx",
+    "Transcribed",  # whisper.rs / parakeet.rs timing line (capital T)
+    "FluidAudio transcript:",  # fluidaudio.rs timing/word-count line
     "Recording started",
     "Recording stopped",
     "Silent recording",
@@ -80,7 +101,16 @@ ALLOW_SUBSTRINGS = (
     "Thoth starting",
 )
 
-HOME_RE = re.compile(r"/Users/[^/\s]+/")
+# Matches macOS (/Users/<user>/) and Linux (/home/<user>/) home paths.
+HOME_RE = re.compile(r"(?:/Users/|/home/)[^/\s]+/")
+
+# Matches the full cpal device-id token (backend:name:serial:index).
+# The human-readable name can contain spaces, so the stop set is only closing
+# delimiters (], ', ") — NOT whitespace. This ensures the USB serial in ids
+# like "coreaudio:AppleUSBAudioEngine:Plantronics:Plantronics Blackwire
+# 3220 Series:DD03779C482045FC88A303FF48A8B6CA:1" is fully consumed.
+# The entire token is replaced with <device-id>.
+DEVICE_ID_RE = re.compile(r"(?:coreaudio|alsa|wasapi):[^\]'\"]+")
 
 
 def to_epoch_ns(ts: str) -> int:
@@ -89,7 +119,7 @@ def to_epoch_ns(ts: str) -> int:
         dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))  # aware UTC
     else:
         dt = datetime.strptime(ts, "%Y-%m-%d %H:%M:%S.%f")  # naive -> local
-    return int(dt.timestamp()) * 1_000_000_000 + dt.microsecond * 1000
+    return round(dt.timestamp() * 1_000_000_000)
 
 
 def classify(rest: str, level: str) -> bool:
@@ -102,8 +132,16 @@ def classify(rest: str, level: str) -> bool:
 
 
 def redact(rest: str) -> str:
-    """Tidy home-directory paths so the literal username is not shipped."""
-    return HOME_RE.sub("~/", rest)
+    """Remove PII-adjacent identifiers before shipping a log line.
+
+    - Home paths: replaces /Users/<user>/ and /home/<user>/ with ~/
+    - Device IDs: replaces opaque cpal id suffixes (USB serials, MAC-like ids)
+      with <device-id> so the backend name survives but the hardware fingerprint
+      does not ship.
+    """
+    rest = HOME_RE.sub("~/", rest)
+    rest = DEVICE_ID_RE.sub("<device-id>", rest)
+    return rest
 
 
 def iter_matches(log_path: str, max_lines: int | None):
@@ -172,6 +210,11 @@ def main() -> int:
         raise SystemExit(f"Log not found: {args.log_path}")
 
     if args.dry_run:
+        print(
+            "WARNING: this script has no idempotency guard. Re-running against a live "
+            "endpoint pushes duplicate entries. Clear the Loki stream first.",
+            file=sys.stderr,
+        )
         by_level = Counter()
         templates = Counter()
         first_ns = last_ns = None
@@ -194,6 +237,11 @@ def main() -> int:
             print(f"  {n:>8}  {tmpl}")
         return 0
 
+    print(
+        "WARNING: no idempotency guard — re-running pushes duplicate entries. "
+        "Clear the target Loki stream before re-running.",
+        file=sys.stderr,
+    )
     url = os.environ.get("LOKI_PUSH_URL")
     if not url:
         raise SystemExit("Set LOKI_PUSH_URL (and optionally LOKI_AUTH, LOKI_TENANT)")

--- a/scripts/loki_backfill.py
+++ b/scripts/loki_backfill.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""One-shot backfill of Thoth's historical operational logs into Grafana Loki.
+
+Thoth's local debug log (``~/.thoth/logs/thoth-debug.log``) holds months of
+human-readable lines. This tool ships ONLY a curated, content-free subset
+(timings, speed factors, recording lifecycle, errors) to a Loki endpoint so a
+power user gets historical observability without ever sending transcript text.
+
+Privacy model: an explicit ALLOW-LIST of message patterns, plus a hard DENY
+net that drops any line carrying the transcript-content marker. The verbatim
+``Transcribed N characters: '<text>'`` line is excluded by construction.
+
+Timestamps: the log changed format partway through its life, so both are
+parsed — early ``2026-02-16T03:07:24.701243Z`` (UTC) and later
+``2026-06-22 09:40:23.914`` (local). Both convert to epoch-nanoseconds.
+
+Loki ingest: pushes oldest->newest per stream (Loki enforces a per-stream
+out-of-order window). The file is already chronological, so file order is
+preserved per stream. Relax ``reject_old_samples_max_age`` on the Loki
+instance before running a months-old backfill.
+
+Usage:
+    # preview what would ship — needs no endpoint, sends nothing
+    python3 scripts/loki_backfill.py --dry-run
+
+    # real push (operator supplies endpoint + token via env)
+    LOKI_PUSH_URL=https://loki.example/loki/api/v1/push \\
+    LOKI_AUTH="Bearer <token>" \\
+    python3 scripts/loki_backfill.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections import Counter
+from datetime import datetime
+
+DEFAULT_LOG = os.path.expanduser("~/.thoth/logs/thoth-debug.log")
+
+# Two timestamp formats seen in the log's lifetime.
+ISO_RE = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\s+"
+    r"(?P<level>TRACE|DEBUG|INFO|WARN|ERROR)\s+(?P<rest>.*)$"
+)
+LOCAL_RE = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)\s+"
+    r"(?P<level>TRACE|DEBUG|INFO|WARN|ERROR)\s+(?P<rest>.*)$"
+)
+
+# Hard DENY: the verbatim-transcript marker. Any line containing this is
+# dropped regardless of level. This is the structural privacy guarantee.
+TRANSCRIPT_MARKERS = ("characters: '", 'characters: "')
+
+# ALLOW-LIST: substrings of valuable, content-free observability/performance
+# events. WARN/ERROR lines are allowed wholesale (minus the DENY net) because
+# operational failures are the point of the export.
+ALLOW_SUBSTRINGS = (
+    "Transcription took",
+    "transcribed",  # "FluidAudio transcribed Ns audio in Ns (RTFx: N)" — speed factor
+    "RTFx",
+    "Recording started",
+    "Recording stopped",
+    "Silent recording",
+    "Filtered text to",  # char count, no text
+    "Enhanced text to",  # char count, no text
+    "Enhancement failed",
+    "Using configured audio device",
+    "Whisper transcription service initialised",
+    "model loaded",
+    "Model loaded",
+    "Metal GPU",
+    "Database initialised",
+    "Thoth starting",
+)
+
+HOME_RE = re.compile(r"/Users/[^/\s]+/")
+
+
+def to_epoch_ns(ts: str) -> int:
+    """Convert a parsed timestamp string to epoch-nanoseconds (UTC)."""
+    if ts.endswith("Z"):
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))  # aware UTC
+    else:
+        dt = datetime.strptime(ts, "%Y-%m-%d %H:%M:%S.%f")  # naive -> local
+    return int(dt.timestamp()) * 1_000_000_000 + dt.microsecond * 1000
+
+
+def classify(rest: str, level: str) -> bool:
+    """Return True if this line should ship (content-free + valuable)."""
+    if any(m in rest for m in TRANSCRIPT_MARKERS):
+        return False  # hard deny — carries transcript text
+    if level in ("WARN", "ERROR"):
+        return True
+    return any(s in rest for s in ALLOW_SUBSTRINGS)
+
+
+def redact(rest: str) -> str:
+    """Tidy home-directory paths so the literal username is not shipped."""
+    return HOME_RE.sub("~/", rest)
+
+
+def iter_matches(log_path: str, max_lines: int | None):
+    """Yield (epoch_ns, level, message) for each allowed line."""
+    seen = 0
+    with open(log_path, "r", errors="replace") as fh:
+        for line in fh:
+            line = line.rstrip("\n")
+            m = ISO_RE.match(line) or LOCAL_RE.match(line)
+            if not m:
+                continue
+            level, rest = m.group("level"), m.group("rest")
+            if not classify(rest, level):
+                continue
+            try:
+                ns = to_epoch_ns(m.group("ts"))
+            except ValueError:
+                continue
+            yield ns, level, redact(rest)
+            seen += 1
+            if max_lines and seen >= max_lines:
+                return
+
+
+def push_batch(url: str, headers: dict, streams: dict) -> None:
+    """POST one batch of streams to Loki, retrying on 429/5xx."""
+    payload = {
+        "streams": [{"stream": labels, "values": values} for labels, values in streams]
+    }
+    body = json.dumps(payload).encode("utf-8")
+    backoff = 1.0
+    for attempt in range(6):
+        req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                if resp.status in (200, 204):
+                    return
+        except urllib.error.HTTPError as e:
+            if e.code in (429, 500, 502, 503) and attempt < 5:
+                time.sleep(backoff)
+                backoff = min(backoff * 2, 30)
+                continue
+            detail = e.read().decode("utf-8", "replace")[:300]
+            raise SystemExit(f"Loki push failed {e.code}: {detail}")
+        except urllib.error.URLError as e:
+            if attempt < 5:
+                time.sleep(backoff)
+                backoff = min(backoff * 2, 30)
+                continue
+            raise SystemExit(f"Loki unreachable: {e}")
+    raise SystemExit("Loki push failed after retries")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--log-path", default=DEFAULT_LOG)
+    ap.add_argument("--dry-run", action="store_true", help="report only; send nothing")
+    ap.add_argument("--batch-size", type=int, default=2000, help="log lines per push")
+    ap.add_argument(
+        "--max-lines", type=int, default=None, help="cap matched lines (testing)"
+    )
+    ap.add_argument("--throttle-ms", type=int, default=150, help="pause between pushes")
+    args = ap.parse_args()
+
+    if not os.path.exists(args.log_path):
+        raise SystemExit(f"Log not found: {args.log_path}")
+
+    if args.dry_run:
+        by_level = Counter()
+        templates = Counter()
+        first_ns = last_ns = None
+        total = 0
+        for ns, level, msg in iter_matches(args.log_path, args.max_lines):
+            total += 1
+            by_level[level] += 1
+            first_ns = ns if first_ns is None else min(first_ns, ns)
+            last_ns = ns if last_ns is None else max(last_ns, ns)
+            # collapse numbers so templates group; first 60 chars only.
+            templates[re.sub(r"\d+\.?\d*", "N", msg)[:60]] += 1
+        print(f"matched {total} content-free lines from {args.log_path}")
+        if first_ns:
+            f = datetime.fromtimestamp(first_ns / 1e9)
+            l = datetime.fromtimestamp(last_ns / 1e9)
+            print(f"range: {f:%Y-%m-%d %H:%M} .. {l:%Y-%m-%d %H:%M}")
+        print("by level:", dict(by_level))
+        print("\ntop message templates that WOULD ship (numbers collapsed to N):")
+        for tmpl, n in templates.most_common(25):
+            print(f"  {n:>8}  {tmpl}")
+        return 0
+
+    url = os.environ.get("LOKI_PUSH_URL")
+    if not url:
+        raise SystemExit("Set LOKI_PUSH_URL (and optionally LOKI_AUTH, LOKI_TENANT)")
+    headers = {"Content-Type": "application/json"}
+    if os.environ.get("LOKI_AUTH"):
+        headers["Authorization"] = os.environ["LOKI_AUTH"]
+    if os.environ.get("LOKI_TENANT"):
+        headers["X-Scope-OrgID"] = os.environ["LOKI_TENANT"]
+
+    base_labels = {"job": "thoth-backfill", "app": "thoth"}
+    # buffer per level so each Loki stream stays timestamp-ordered.
+    buffers: dict[str, list] = {}
+    pushed = 0
+    pending = 0
+
+    def flush():
+        nonlocal pending
+        streams = []
+        for level, values in buffers.items():
+            if values:
+                labels = dict(base_labels, level=level.lower())
+                streams.append((labels, values))
+        if streams:
+            push_batch(url, headers, streams)
+            for v in buffers.values():
+                v.clear()
+            time.sleep(args.throttle_ms / 1000.0)
+        pending = 0
+
+    for ns, level, msg in iter_matches(args.log_path, args.max_lines):
+        buffers.setdefault(level, []).append([str(ns), msg])
+        pending += 1
+        pushed += 1
+        if pending >= args.batch_size:
+            flush()
+        if pushed % 20000 == 0:
+            print(f"  pushed {pushed} lines...", file=sys.stderr)
+    flush()
+    print(f"done — pushed {pushed} content-free lines to Loki")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4792,6 +4792,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5897,6 +5922,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2 0.11.0",
  "sherpa-onnx",
  "strsim",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -715,6 +715,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,8 +1910,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1915,9 +1923,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2197,6 +2207,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "hound"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,6 +2322,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2834,6 +2856,22 @@ name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "loki-api"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdc38a304f59a03e6efa3876766a48c70a766a93f88341c3fff4212834b8e327"
+dependencies = [
+ "prost",
+ "prost-types",
+]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mach2"
@@ -3828,6 +3866,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3846,6 +3916,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4027,6 +4152,44 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.7",
+]
 
 [[package]]
 name = "reqwest"
@@ -4283,6 +4446,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -4780,6 +4944,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
 name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4920,6 +5090,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "symphonia"
@@ -5269,7 +5445,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -5495,7 +5671,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.13.4",
  "rustls",
  "semver",
  "serde",
@@ -5699,6 +5875,7 @@ dependencies = [
  "fluidaudio-rs",
  "futures-util",
  "getrandom 0.4.2",
+ "hostname",
  "hound",
  "mockito",
  "num_cpus",
@@ -5711,7 +5888,7 @@ dependencies = [
  "open",
  "parking_lot",
  "regex",
- "reqwest",
+ "reqwest 0.13.4",
  "rmcp",
  "rphonetic",
  "rubato",
@@ -5741,6 +5918,8 @@ dependencies = [
  "tokio-util",
  "tower-http",
  "tracing",
+ "tracing-appender",
+ "tracing-loki",
  "tracing-subscriber",
  "url",
  "uuid",
@@ -6072,6 +6251,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6100,6 +6292,36 @@ checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-loki"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1ad78bf74c1790b0825ddc35ad1bb9498736c51c8437796b81cadf4916cd8"
+dependencies = [
+ "loki-api",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "snap",
+ "tokio",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
  "tracing-core",
 ]
 
@@ -6598,6 +6820,16 @@ name = "web-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -96,6 +96,11 @@ anyhow = "1.0"
 thiserror = "2.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# Rolling file appender for daily log rotation
+tracing-appender = "0.2"
+# Loki log forwarding layer (optional telemetry export)
+# Uses rustls + ring for TLS (no aws-lc-sys, which fails under -march=armv8-a)
+tracing-loki = { version = "0.2.7", default-features = false, features = ["rustls", "compat-0-2-1"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 parking_lot = "0.12"
@@ -108,6 +113,7 @@ rphonetic = "3"
 strsim = "0.11"
 num_cpus = "1.17"
 tempfile = "3.25"
+hostname = "0.4"
 
 # Desktop-specific (macOS, Windows, Linux)
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -169,6 +169,7 @@ x11rb = { version = "0.13", features = ["allow-unsafe-code"] }
 whisper-rs = { version = "0.16", default-features = false }
 [dev-dependencies]
 mockito = "1"
+serial_test = "3"
 
 [profile.release]
 panic = "abort"

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -741,6 +741,21 @@ fn get_config_instance() -> &'static RwLock<Config> {
     })
 }
 
+/// Return the real (unmasked) stored loki_auth token for internal use only.
+///
+/// This bypasses the masking applied by `get_config()` and must NEVER be
+/// forwarded to the frontend, logged, or included in any IPC response.
+/// Used exclusively by `test_loki_connection` to resolve the effective token
+/// when the frontend passes back the mask sentinel.
+pub(crate) fn get_raw_loki_auth() -> String {
+    get_config_instance().read().logging.loki_auth.0.clone()
+}
+
+/// Return the stored loki_tenant for internal use only.
+pub(crate) fn get_raw_loki_tenant() -> Option<String> {
+    get_config_instance().read().logging.loki_tenant.clone()
+}
+
 // --- IPC Commands ---
 
 /// Get the current configuration
@@ -1562,19 +1577,19 @@ mod tests {
     #[test]
     fn test_telemetry_filter_allows_telemetry_target() {
         // The allow-list filter used by the Loki layer must pass "telemetry" target events.
-        // We test the predicate logic directly without constructing a real subscriber.
-        let target = "telemetry";
-        let passes = target == "telemetry";
-        assert!(passes, "telemetry target must pass the filter");
+        // Calls the live predicate via its target-string shim so a rename would break this test.
+        assert!(
+            crate::telemetry::is_telemetry_event_by_target("telemetry"),
+            "telemetry target must pass the filter"
+        );
     }
 
     #[test]
     fn test_telemetry_filter_blocks_other_targets() {
         // Non-telemetry targets must not pass the Loki filter.
         for target in &["thoth::pipeline", "thoth::audio", "tracing", "info"] {
-            let passes = *target == "telemetry";
             assert!(
-                !passes,
+                !crate::telemetry::is_telemetry_event_by_target(target),
                 "target '{target}' must be blocked by the telemetry filter"
             );
         }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -21,16 +21,16 @@ static CONFIG: OnceLock<RwLock<Config>> = OnceLock::new();
 
 /// Integrations configuration (Local Control API, MCP server)
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+#[serde(default)]
 pub struct IntegrationsConfig {
     /// Whether the Local Control API HTTP server is enabled
-    #[serde(default)]
+    #[serde(default, alias = "apiEnabled")]
     pub api_enabled: bool,
     /// Port for the Local Control API (default 8765)
-    #[serde(default = "default_api_port")]
+    #[serde(default = "default_api_port", alias = "apiPort")]
     pub api_port: u16,
     /// Whether the MCP server is enabled
-    #[serde(default)]
+    #[serde(default, alias = "mcpEnabled")]
     pub mcp_enabled: bool,
 }
 
@@ -56,28 +56,28 @@ impl Default for IntegrationsConfig {
 ///
 /// Local file logging is always on. The Loki layer is opt-in; changes apply on restart.
 #[derive(Clone, Serialize, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+#[serde(default)]
 pub struct LoggingConfig {
     /// Number of daily rolling log files to retain locally (default 7)
-    #[serde(default = "default_local_retention_days")]
+    #[serde(default = "default_local_retention_days", alias = "localRetentionDays")]
     pub local_retention_days: u32,
     /// Whether to forward telemetry events to a remote Loki instance (default false)
-    #[serde(default)]
+    #[serde(default, alias = "remoteEnabled")]
     pub remote_enabled: bool,
     /// Loki push endpoint URL (e.g. "http://loki:3100")
-    #[serde(default)]
+    #[serde(default, alias = "lokiUrl")]
     pub loki_url: String,
     /// Authorization header value (e.g. "Bearer glsa_xxx"). Stored locally; never logged.
-    #[serde(default)]
+    #[serde(default, alias = "lokiAuth")]
     pub loki_auth: LokiAuth,
     /// Optional X-Scope-OrgID tenant header value
-    #[serde(default)]
+    #[serde(default, alias = "lokiTenant")]
     pub loki_tenant: Option<String>,
     /// Additional Loki stream labels (e.g. `[["env", "prod"]]`)
-    #[serde(default)]
+    #[serde(default, alias = "lokiLabels")]
     pub loki_labels: Vec<[String; 2]>,
     /// Minimum tracing level for telemetry events ("info", "debug", etc.)
-    #[serde(default = "default_telemetry_level")]
+    #[serde(default = "default_telemetry_level", alias = "telemetryLevel")]
     pub telemetry_level: String,
 }
 
@@ -103,12 +103,26 @@ impl Default for LoggingConfig {
     }
 }
 
+/// Sentinel returned over the API/IPC instead of the real token value.
+///
+/// The frontend must send this value back unchanged (or empty) to avoid wiping
+/// a stored token on a generic settings save. `set_config` treats both `""`
+/// and this sentinel as "keep the existing stored token".
+pub(crate) const LOKI_AUTH_MASK: &str = "***";
+
 /// Wrapper for the Loki authorization token.
 ///
 /// The value is redacted from `Debug` output so it never appears in logs.
 #[derive(Clone, Default, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct LokiAuth(pub String);
+
+impl LokiAuth {
+    /// Return `true` if the value is the API mask sentinel or is empty.
+    pub(crate) fn is_masked_or_empty(&self) -> bool {
+        self.0.is_empty() || self.0 == LOKI_AUTH_MASK
+    }
+}
 
 impl std::fmt::Debug for LokiAuth {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -171,6 +185,20 @@ impl Default for Config {
             integrations: IntegrationsConfig::default(),
             logging: LoggingConfig::default(),
         }
+    }
+}
+
+impl Config {
+    /// Return a copy of this config with `loki_auth` replaced by the API mask
+    /// sentinel when a token is stored.
+    ///
+    /// Use this for all IPC/API/MCP responses so the real token value never
+    /// crosses the serialisation boundary into chat history or logs.
+    pub(crate) fn with_masked_loki_auth(mut self) -> Self {
+        if !self.logging.loki_auth.0.is_empty() {
+            self.logging.loki_auth = LokiAuth(LOKI_AUTH_MASK.to_string());
+        }
+        self
     }
 }
 
@@ -632,11 +660,12 @@ fn get_config_instance() -> &'static RwLock<Config> {
 /// Get the current configuration
 ///
 /// Returns the current configuration state. The config is cached in memory
-/// and loaded from disk on first access.
+/// and loaded from disk on first access. The `loki_auth` token is replaced
+/// with the mask sentinel so the real value never crosses the IPC boundary.
 #[tauri::command]
 pub fn get_config() -> Result<Config, Error> {
     let config = get_config_instance().read().clone();
-    Ok(config)
+    Ok(config.with_masked_loki_auth())
 }
 
 /// Update the configuration
@@ -728,6 +757,16 @@ pub fn set_config(mut config: Config) -> Result<(), Error> {
             tracing::debug!("Preserving enhancement.api_key (incoming config had None)");
             config.enhancement.api_key = current.enhancement.api_key.clone();
         }
+
+        // Preserve loki_auth if the incoming value is empty or the API mask sentinel
+        // and the cached config has a real token. The frontend never receives the real
+        // token (get_config masks it), so a generic save must not wipe a stored token.
+        // Use the dedicated set_loki_auth command for intentional token changes.
+        if config.logging.loki_auth.is_masked_or_empty() && !current.logging.loki_auth.0.is_empty()
+        {
+            tracing::debug!("Preserving loki_auth (incoming config had empty/masked value)");
+            config.logging.loki_auth = current.logging.loki_auth.clone();
+        }
     }
 
     // Save to disk first
@@ -815,6 +854,30 @@ pub fn set_enhancement_api_key(key: Option<String>) -> Result<(), Error> {
             "updated"
         } else {
             "cleared"
+        }
+    );
+    Ok(())
+}
+
+/// Set or clear the Loki auth token unconditionally.
+///
+/// This is the only correct path for changing the token (including clearing it
+/// to empty). The preservation guard in `set_config` prevents the generic save
+/// from wiping the token with a masked/empty value; this command bypasses that
+/// guard so an explicit user action can still clear it.
+///
+/// Pass `Some(token)` to store a new token, `None` to clear it.
+#[tauri::command]
+pub fn set_loki_auth(token: Option<String>) -> Result<(), Error> {
+    let mut cached = get_config_instance().write();
+    cached.logging.loki_auth = LokiAuth(token.unwrap_or_default());
+    save_to_disk(&cached)?;
+    tracing::info!(
+        "loki_auth {}",
+        if cached.logging.loki_auth.0.is_empty() {
+            "cleared"
+        } else {
+            "updated"
         }
     );
     Ok(())
@@ -1429,5 +1492,204 @@ mod tests {
                 "target '{target}' must be blocked by the telemetry filter"
             );
         }
+    }
+
+    // =========================================================================
+    // Logging config persistence and token handling tests (Bug 1 / Bug 3)
+    // =========================================================================
+
+    #[test]
+    fn test_logging_config_snake_case_serde() {
+        // The frontend serialises logging fields as snake_case; verify they round-trip
+        // correctly now that rename_all = "camelCase" has been removed.
+        let json = r#"{
+            "local_retention_days": 30,
+            "remote_enabled": true,
+            "loki_url": "http://loki:3100",
+            "loki_auth": "Bearer secret",
+            "loki_tenant": "myorg",
+            "loki_labels": [["env", "prod"]],
+            "telemetry_level": "debug"
+        }"#;
+        let cfg: LoggingConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.local_retention_days, 30);
+        assert!(cfg.remote_enabled);
+        assert_eq!(cfg.loki_url, "http://loki:3100");
+        assert_eq!(cfg.loki_auth.0, "Bearer secret");
+        assert_eq!(cfg.loki_tenant, Some("myorg".to_string()));
+        assert_eq!(cfg.loki_labels.len(), 1);
+        assert_eq!(cfg.telemetry_level, "debug");
+    }
+
+    #[test]
+    fn test_logging_config_camel_case_alias_still_deserialises() {
+        // Existing camelCase disk files must still parse correctly via the alias annotations.
+        let json = r#"{
+            "localRetentionDays": 14,
+            "remoteEnabled": true,
+            "lokiUrl": "http://loki:3100",
+            "lokiAuth": "Bearer token",
+            "lokiTenant": null,
+            "lokiLabels": [],
+            "telemetryLevel": "info"
+        }"#;
+        let cfg: LoggingConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.local_retention_days, 14);
+        assert!(cfg.remote_enabled);
+        assert_eq!(cfg.loki_url, "http://loki:3100");
+        assert_eq!(cfg.loki_auth.0, "Bearer token");
+    }
+
+    #[test]
+    fn test_logging_config_full_config_snake_case_roundtrip() {
+        // Simulate what the frontend sends via set_config: snake_case keys for logging.
+        let json = r#"{
+            "version": 1,
+            "logging": {
+                "local_retention_days": 14,
+                "remote_enabled": true,
+                "loki_url": "http://loki:3100",
+                "loki_auth": "Bearer glsa_test",
+                "loki_tenant": null,
+                "loki_labels": [],
+                "telemetry_level": "debug"
+            }
+        }"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert_eq!(config.logging.local_retention_days, 14);
+        assert!(config.logging.remote_enabled);
+        assert_eq!(config.logging.loki_url, "http://loki:3100");
+        assert_eq!(config.logging.loki_auth.0, "Bearer glsa_test");
+        assert_eq!(config.logging.telemetry_level, "debug");
+    }
+
+    #[test]
+    fn test_config_with_masked_loki_auth_masks_set_token() {
+        // with_masked_loki_auth replaces a set token with the sentinel.
+        let config = Config {
+            logging: LoggingConfig {
+                loki_auth: LokiAuth("real_secret_token".to_string()),
+                ..LoggingConfig::default()
+            },
+            ..Config::default()
+        };
+        let masked = config.with_masked_loki_auth();
+        assert_eq!(masked.logging.loki_auth.0, LOKI_AUTH_MASK);
+    }
+
+    #[test]
+    fn test_config_with_masked_loki_auth_leaves_empty_token_alone() {
+        // with_masked_loki_auth does not replace an empty token (nothing to hide).
+        let config = Config::default();
+        let masked = config.with_masked_loki_auth();
+        assert!(masked.logging.loki_auth.0.is_empty());
+    }
+
+    #[test]
+    fn test_loki_auth_is_masked_or_empty() {
+        assert!(LokiAuth(String::new()).is_masked_or_empty());
+        assert!(LokiAuth(LOKI_AUTH_MASK.to_string()).is_masked_or_empty());
+        assert!(!LokiAuth("real_token".to_string()).is_masked_or_empty());
+    }
+
+    #[test]
+    fn test_set_config_preserves_loki_auth_on_empty_incoming() {
+        // A set_config with empty loki_auth must keep the stored token.
+        let _guard = CONFIG_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let instance = get_config_instance();
+        {
+            let mut cached = instance.write();
+            cached.logging.loki_auth = LokiAuth("stored_token".to_string());
+        }
+
+        let mut incoming = Config::default();
+        // Simulate what the frontend sends: empty token (field not changed)
+        assert!(incoming.logging.loki_auth.0.is_empty());
+
+        // Apply the same preservation guard that set_config uses
+        {
+            let current = instance.read();
+            if incoming.logging.loki_auth.is_masked_or_empty()
+                && !current.logging.loki_auth.0.is_empty()
+            {
+                incoming.logging.loki_auth = current.logging.loki_auth.clone();
+            }
+        }
+
+        assert_eq!(incoming.logging.loki_auth.0, "stored_token");
+
+        // Restore clean state
+        instance.write().logging.loki_auth = LokiAuth::default();
+    }
+
+    #[test]
+    fn test_set_config_preserves_loki_auth_on_mask_sentinel_incoming() {
+        // A set_config with loki_auth == LOKI_AUTH_MASK must keep the stored token.
+        // This happens when the frontend sends back the mask it received from get_config.
+        let _guard = CONFIG_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let instance = get_config_instance();
+        {
+            let mut cached = instance.write();
+            cached.logging.loki_auth = LokiAuth("stored_token_xyz".to_string());
+        }
+
+        let mut incoming = Config::default();
+        incoming.logging.loki_auth = LokiAuth(LOKI_AUTH_MASK.to_string());
+
+        {
+            let current = instance.read();
+            if incoming.logging.loki_auth.is_masked_or_empty()
+                && !current.logging.loki_auth.0.is_empty()
+            {
+                incoming.logging.loki_auth = current.logging.loki_auth.clone();
+            }
+        }
+
+        assert_eq!(incoming.logging.loki_auth.0, "stored_token_xyz");
+
+        // Restore clean state
+        instance.write().logging.loki_auth = LokiAuth::default();
+    }
+
+    #[test]
+    fn test_logging_config_file_persistence_roundtrip() {
+        // Verify that write → read file gives back the same values.
+        // Uses a temp directory so it does not touch ~/.thoth/config.json.
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config_test.json");
+
+        let cfg = Config {
+            logging: LoggingConfig {
+                local_retention_days: 30,
+                remote_enabled: true,
+                loki_url: "http://loki:3100".to_string(),
+                loki_auth: LokiAuth("Bearer glsa_secret".to_string()),
+                loki_tenant: Some("testorg".to_string()),
+                loki_labels: vec![["env".to_string(), "test".to_string()]],
+                telemetry_level: "debug".to_string(),
+            },
+            ..Config::default()
+        };
+
+        // Write
+        let contents = serde_json::to_string_pretty(&cfg).unwrap();
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(contents.as_bytes())
+            .unwrap();
+
+        // Read back
+        let read_back = std::fs::read_to_string(&path).unwrap();
+        let restored: Config = serde_json::from_str(&read_back).unwrap();
+
+        assert_eq!(restored.logging.local_retention_days, 30);
+        assert!(restored.logging.remote_enabled);
+        assert_eq!(restored.logging.loki_url, "http://loki:3100");
+        assert_eq!(restored.logging.loki_auth.0, "Bearer glsa_secret");
+        assert_eq!(restored.logging.loki_tenant, Some("testorg".to_string()));
+        assert_eq!(restored.logging.loki_labels.len(), 1);
+        assert_eq!(restored.logging.loki_labels[0], ["env", "test"]);
+        assert_eq!(restored.logging.telemetry_level, "debug");
     }
 }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -521,6 +521,73 @@ impl Default for RecorderConfig {
     }
 }
 
+/// Recursively merge `patch` into `target` (objects merged key-wise; other values replaced).
+///
+/// Used by the MCP `setting update` handler and the HTTP PATCH `/settings` handler so
+/// both partial-update paths share one implementation.
+pub(crate) fn merge_json(target: &mut serde_json::Value, patch: &serde_json::Value) {
+    match (target, patch) {
+        (serde_json::Value::Object(t), serde_json::Value::Object(p)) => {
+            for (k, v) in p {
+                merge_json(t.entry(k.clone()).or_insert(serde_json::Value::Null), v);
+            }
+        }
+        (t, p) => *t = p.clone(),
+    }
+}
+
+/// Recursively convert every object key in `value` from camelCase to snake_case.
+///
+/// The config always serialises to snake_case (no `rename_all` on the structs; the
+/// `alias` annotations only add camelCase as a second *input* name). An MCP or HTTP
+/// caller that sends `{"localRetentionDays": 14}` adds a key that serde never
+/// matches to `local_retention_days` but also doesn't remove the existing one, so
+/// the merged `Value` ends up with both keys and serde errors on "duplicate field".
+///
+/// Canonicalising before the merge resolves this: every incoming key is
+/// normalised to the same form the config serialises to, so the merge updates the
+/// existing key in-place. The transform is idempotent (snake_case → snake_case
+/// passes through unchanged) and handles nested objects recursively.
+///
+/// Arrays are also recursed so future array-of-objects config fields (e.g.
+/// `loki_labels`) have their nested object keys canonicalised too.
+pub(crate) fn canonicalise_patch_keys(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let new_map = map
+                .into_iter()
+                .map(|(k, v)| (camel_to_snake(&k), canonicalise_patch_keys(v)))
+                .collect();
+            serde_json::Value::Object(new_map)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.into_iter().map(canonicalise_patch_keys).collect())
+        }
+        other => other,
+    }
+}
+
+/// Convert a single camelCase identifier to snake_case.
+///
+/// Inserts an underscore before each uppercase ASCII letter and lowercases it.
+/// All-lowercase and already-snake_case identifiers pass through unchanged.
+/// A leading underscore (which would appear if the first char were uppercase)
+/// is stripped so inputs like `"URL"` → `"u_r_l"` rather than `"_u_r_l"`.
+fn camel_to_snake(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    for ch in s.chars() {
+        if ch.is_ascii_uppercase() {
+            out.push('_');
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    // A key that starts with an uppercase letter would produce a leading '_';
+    // strip it so the result is a valid identifier.
+    out.trim_start_matches('_').to_string()
+}
+
 /// Get the path to the config file (~/.thoth/config.json)
 pub fn get_config_path() -> PathBuf {
     home_dir_or_fallback().join(".thoth").join("config.json")
@@ -1736,5 +1803,224 @@ mod tests {
         assert_eq!(restored.logging.loki_labels.len(), 1);
         assert_eq!(restored.logging.loki_labels[0], ["env", "test"]);
         assert_eq!(restored.logging.telemetry_level, "debug");
+    }
+
+    // =========================================================================
+    // canonicalise_patch_keys / merge_json tests (Bug 1 + Bug 2)
+    // =========================================================================
+
+    #[test]
+    fn test_camel_to_snake_identity_on_snake_case() {
+        // Already-snake_case keys must pass through unchanged (idempotent).
+        for key in &[
+            "local_retention_days",
+            "loki_url",
+            "remote_enabled",
+            "api_enabled",
+            "mcp_enabled",
+        ] {
+            assert_eq!(
+                camel_to_snake(key),
+                *key,
+                "snake_case key must be unchanged: {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_camel_to_snake_converts_known_field_aliases() {
+        // Every field that carries a camelCase alias must round-trip to exactly the
+        // snake_case canonical name that serde serialises it as.
+        let pairs = [
+            ("localRetentionDays", "local_retention_days"),
+            ("remoteEnabled", "remote_enabled"),
+            ("lokiUrl", "loki_url"),
+            ("lokiAuth", "loki_auth"),
+            ("lokiTenant", "loki_tenant"),
+            ("lokiLabels", "loki_labels"),
+            ("telemetryLevel", "telemetry_level"),
+            ("apiEnabled", "api_enabled"),
+            ("apiPort", "api_port"),
+            ("mcpEnabled", "mcp_enabled"),
+        ];
+        for (camel, snake) in pairs {
+            assert_eq!(
+                camel_to_snake(camel),
+                snake,
+                "camelCase alias {camel} must convert to {snake}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_canonicalise_patch_keys_flat_camel_patch() {
+        // A flat camelCase patch must deserialise successfully after canonicalisation.
+        let patch_json = serde_json::json!({
+            "localRetentionDays": 14_u32,
+            "remoteEnabled": true,
+            "lokiUrl": "http://loki:3100"
+        });
+        let canon = canonicalise_patch_keys(patch_json);
+        // Keys must now be snake_case.
+        let obj = canon.as_object().unwrap();
+        assert!(
+            obj.contains_key("local_retention_days"),
+            "key canonicalised"
+        );
+        assert!(obj.contains_key("remote_enabled"), "key canonicalised");
+        assert!(obj.contains_key("loki_url"), "key canonicalised");
+        assert!(!obj.contains_key("localRetentionDays"), "old key removed");
+    }
+
+    #[test]
+    fn test_canonicalise_patch_keys_nested_camel_patch() {
+        // Nested camelCase patch (e.g. {"logging": {"localRetentionDays": 14}})
+        // must be fully canonicalised.
+        let patch_json = serde_json::json!({
+            "logging": {
+                "localRetentionDays": 30_u32,
+                "remoteEnabled": false
+            }
+        });
+        let canon = canonicalise_patch_keys(patch_json);
+        let logging = canon.get("logging").unwrap().as_object().unwrap();
+        assert!(logging.contains_key("local_retention_days"));
+        assert!(logging.contains_key("remote_enabled"));
+        assert!(!logging.contains_key("localRetentionDays"));
+    }
+
+    #[test]
+    fn test_camel_patch_merges_and_deserialises_without_duplicate_field_error() {
+        // Simulates Bug 1: a camelCase MCP patch must merge onto the serialised config
+        // and deserialise back to Config without a "duplicate field" error.
+        let current_cfg = Config::default();
+        let mut current_val = serde_json::to_value(&current_cfg).unwrap();
+
+        let patch = serde_json::json!({ "logging": { "localRetentionDays": 30_u32 } });
+        let patch = canonicalise_patch_keys(patch);
+        merge_json(&mut current_val, &patch);
+
+        let result: Result<Config, _> = serde_json::from_value(current_val);
+        assert!(
+            result.is_ok(),
+            "camelCase patch must deserialise without error: {:?}",
+            result.err()
+        );
+        assert_eq!(result.unwrap().logging.local_retention_days, 30);
+    }
+
+    #[test]
+    fn test_snake_patch_merges_and_deserialises_correctly() {
+        // snake_case patch must also work (idempotent canonicalisation).
+        let current_cfg = Config::default();
+        let mut current_val = serde_json::to_value(&current_cfg).unwrap();
+
+        let patch = serde_json::json!({ "logging": { "local_retention_days": 21_u32 } });
+        let patch = canonicalise_patch_keys(patch);
+        merge_json(&mut current_val, &patch);
+
+        let result: Result<Config, _> = serde_json::from_value(current_val);
+        assert!(
+            result.is_ok(),
+            "snake_case patch must deserialise: {:?}",
+            result.err()
+        );
+        assert_eq!(result.unwrap().logging.local_retention_days, 21);
+    }
+
+    #[test]
+    fn test_partial_patch_preserves_untouched_fields() {
+        // Simulates Bug 2: a partial patch that only sets one field must leave all
+        // other fields at their prior values.
+        let mut prior = Config::default();
+        prior.logging.local_retention_days = 42;
+        prior.logging.loki_url = "http://prior:3100".to_string();
+
+        let mut current_val = serde_json::to_value(&prior).unwrap();
+
+        // Patch only changes remote_enabled; local_retention_days and loki_url must survive.
+        let patch = serde_json::json!({ "logging": { "remoteEnabled": true } });
+        let patch = canonicalise_patch_keys(patch);
+        merge_json(&mut current_val, &patch);
+
+        let result: Config = serde_json::from_value(current_val).unwrap();
+        assert!(result.logging.remote_enabled, "patched field must be set");
+        assert_eq!(
+            result.logging.local_retention_days, 42,
+            "unpatched field must be preserved"
+        );
+        assert_eq!(
+            result.logging.loki_url, "http://prior:3100",
+            "unpatched field must be preserved"
+        );
+    }
+
+    // =========================================================================
+    // loki_auth preservation through the merge pipeline (HIGH invariant)
+    //
+    // The merge base comes from get_config(), which masks loki_auth as "***".
+    // set_config()'s guard treats both empty and the mask sentinel as "keep the
+    // stored token". These tests pin that invariant at the merge-pipeline level.
+    // =========================================================================
+
+    #[test]
+    fn test_merge_pipeline_loki_auth_omitted_carries_mask_sentinel() {
+        // When a patch omits loki_auth entirely, the merge base's masked value
+        // ("***") survives unchanged into the merged Value. set_config will then
+        // recognise it as the sentinel and restore the real stored token.
+        // This test verifies the merge step itself — not set_config's guard —
+        // by asserting the sentinel is still present after the merge.
+        let mut base = Config::default();
+        // Simulate what get_config() returns: real token replaced by sentinel.
+        base.logging.loki_auth = LokiAuth(LOKI_AUTH_MASK.to_string());
+        let mut base_val = serde_json::to_value(&base).unwrap();
+
+        // Patch that deliberately does NOT include loki_auth.
+        let patch = serde_json::json!({ "logging": { "remote_enabled": true } });
+        let patch = canonicalise_patch_keys(patch);
+        merge_json(&mut base_val, &patch);
+
+        let merged: Config = serde_json::from_value(base_val).unwrap();
+        assert_eq!(
+            merged.logging.loki_auth.0, LOKI_AUTH_MASK,
+            "mask sentinel must survive the merge when patch omits loki_auth"
+        );
+        // set_config's guard will see LOKI_AUTH_MASK and restore the real token.
+        assert!(merged.logging.loki_auth.is_masked_or_empty());
+    }
+
+    #[test]
+    fn test_merge_pipeline_loki_auth_sent_as_sentinel_still_masked() {
+        // When a patch explicitly sends the mask sentinel for loki_auth (e.g. the
+        // MCP client echoed back what get_config returned), the merged Value still
+        // carries the sentinel and set_config's guard preserves the real token.
+        let mut base = Config::default();
+        base.logging.loki_auth = LokiAuth(LOKI_AUTH_MASK.to_string());
+        let mut base_val = serde_json::to_value(&base).unwrap();
+
+        let patch = serde_json::json!({
+            "logging": { "loki_auth": LOKI_AUTH_MASK }
+        });
+        let patch = canonicalise_patch_keys(patch);
+        merge_json(&mut base_val, &patch);
+
+        let merged: Config = serde_json::from_value(base_val).unwrap();
+        assert_eq!(
+            merged.logging.loki_auth.0, LOKI_AUTH_MASK,
+            "sentinel patch must keep the sentinel in the merged value"
+        );
+        assert!(merged.logging.loki_auth.is_masked_or_empty());
+    }
+
+    #[test]
+    fn test_camel_to_snake_no_leading_underscore_on_uppercase_start() {
+        // An input that starts with uppercase must not produce a leading underscore.
+        assert_eq!(camel_to_snake("URL"), "u_r_l");
+        assert_eq!(&camel_to_snake("URL")[..1], "u");
+        // No current config field starts uppercase, but the guard must hold.
+        assert!(
+            !camel_to_snake("Foo").starts_with('_'),
+            "leading underscore must be stripped"
+        );
     }
 }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -124,6 +124,25 @@ impl LokiAuth {
     }
 }
 
+/// Build the value for the HTTP `Authorization` header from a stored auth
+/// token. Returns `None` when there is no usable token (empty or the API mask
+/// sentinel). A value that already carries an auth scheme (`Bearer `/`Basic `,
+/// case-insensitive) is used verbatim; a bare token gets a `Bearer ` prefix —
+/// so the user can paste just the token (the common case) and still satisfy a
+/// `Authorization: Bearer <token>` check.
+pub(crate) fn authorization_header(auth: &str) -> Option<String> {
+    let token = auth.trim();
+    if token.is_empty() || token == LOKI_AUTH_MASK {
+        return None;
+    }
+    let lower = token.to_ascii_lowercase();
+    if lower.starts_with("bearer ") || lower.starts_with("basic ") {
+        Some(token.to_string())
+    } else {
+        Some(format!("Bearer {token}"))
+    }
+}
+
 impl std::fmt::Debug for LokiAuth {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.0.is_empty() {
@@ -1590,6 +1609,32 @@ mod tests {
         assert!(LokiAuth(String::new()).is_masked_or_empty());
         assert!(LokiAuth(LOKI_AUTH_MASK.to_string()).is_masked_or_empty());
         assert!(!LokiAuth("real_token".to_string()).is_masked_or_empty());
+    }
+
+    #[test]
+    fn test_authorization_header() {
+        // empty / masked → no header
+        assert_eq!(authorization_header(""), None);
+        assert_eq!(authorization_header("   "), None);
+        assert_eq!(authorization_header(LOKI_AUTH_MASK), None);
+        // bare token → Bearer prefixed
+        assert_eq!(
+            authorization_header("abc123").as_deref(),
+            Some("Bearer abc123")
+        );
+        // already-schemed values pass through verbatim (case-insensitive match)
+        assert_eq!(
+            authorization_header("Bearer abc123").as_deref(),
+            Some("Bearer abc123")
+        );
+        assert_eq!(
+            authorization_header("bearer abc123").as_deref(),
+            Some("bearer abc123")
+        );
+        assert_eq!(
+            authorization_header("Basic dXNlcjpwYXNz").as_deref(),
+            Some("Basic dXNlcjpwYXNz")
+        );
     }
 
     #[test]

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -52,6 +52,88 @@ impl Default for IntegrationsConfig {
     }
 }
 
+/// Logging and telemetry configuration
+///
+/// Local file logging is always on. The Loki layer is opt-in; changes apply on restart.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct LoggingConfig {
+    /// Number of daily rolling log files to retain locally (default 7)
+    #[serde(default = "default_local_retention_days")]
+    pub local_retention_days: u32,
+    /// Whether to forward telemetry events to a remote Loki instance (default false)
+    #[serde(default)]
+    pub remote_enabled: bool,
+    /// Loki push endpoint URL (e.g. "http://loki:3100")
+    #[serde(default)]
+    pub loki_url: String,
+    /// Authorization header value (e.g. "Bearer glsa_xxx"). Stored locally; never logged.
+    #[serde(default)]
+    pub loki_auth: LokiAuth,
+    /// Optional X-Scope-OrgID tenant header value
+    #[serde(default)]
+    pub loki_tenant: Option<String>,
+    /// Additional Loki stream labels (e.g. `[["env", "prod"]]`)
+    #[serde(default)]
+    pub loki_labels: Vec<[String; 2]>,
+    /// Minimum tracing level for telemetry events ("info", "debug", etc.)
+    #[serde(default = "default_telemetry_level")]
+    pub telemetry_level: String,
+}
+
+fn default_local_retention_days() -> u32 {
+    7
+}
+
+fn default_telemetry_level() -> String {
+    "info".to_string()
+}
+
+impl Default for LoggingConfig {
+    fn default() -> Self {
+        Self {
+            local_retention_days: default_local_retention_days(),
+            remote_enabled: false,
+            loki_url: String::new(),
+            loki_auth: LokiAuth::default(),
+            loki_tenant: None,
+            loki_labels: Vec::new(),
+            telemetry_level: default_telemetry_level(),
+        }
+    }
+}
+
+/// Wrapper for the Loki authorization token.
+///
+/// The value is redacted from `Debug` output so it never appears in logs.
+#[derive(Clone, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct LokiAuth(pub String);
+
+impl std::fmt::Debug for LokiAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0.is_empty() {
+            write!(f, "\"\"")
+        } else {
+            write!(f, "\"***redacted***\"")
+        }
+    }
+}
+
+impl std::fmt::Debug for LoggingConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LoggingConfig")
+            .field("local_retention_days", &self.local_retention_days)
+            .field("remote_enabled", &self.remote_enabled)
+            .field("loki_url", &self.loki_url)
+            .field("loki_auth", &self.loki_auth)
+            .field("loki_tenant", &self.loki_tenant)
+            .field("loki_labels", &self.loki_labels)
+            .field("telemetry_level", &self.telemetry_level)
+            .finish()
+    }
+}
+
 /// Main configuration structure
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -72,6 +154,8 @@ pub struct Config {
     pub recorder: RecorderConfig,
     /// Integrations settings (Local Control API, MCP)
     pub integrations: IntegrationsConfig,
+    /// Logging and telemetry settings
+    pub logging: LoggingConfig,
 }
 
 impl Default for Config {
@@ -85,6 +169,7 @@ impl Default for Config {
             general: GeneralConfig::default(),
             recorder: RecorderConfig::default(),
             integrations: IntegrationsConfig::default(),
+            logging: LoggingConfig::default(),
         }
     }
 }
@@ -501,6 +586,16 @@ fn apply_migration(config: Config) -> Result<Config, String> {
         }
         v => Err(format!("Unknown config version: {}", v)),
     }
+}
+
+/// Read the logging config synchronously from disk without initialising the global
+/// config singleton.
+///
+/// Called early in `init_logging` (before the Tauri event loop starts) so the Loki
+/// subscriber layer can be constructed before any events are emitted. Falls back to
+/// `LoggingConfig::default()` on any error so the app still starts.
+pub(crate) fn read_logging_config_early() -> LoggingConfig {
+    load_from_disk().map(|c| c.logging).unwrap_or_default()
 }
 
 /// Apply the enhancement config to the global backend singleton.
@@ -992,6 +1087,7 @@ mod tests {
                 auto_hide_delay: 5000,
             },
             integrations: IntegrationsConfig::default(),
+            logging: LoggingConfig::default(),
         };
 
         let json = serde_json::to_string_pretty(&config).unwrap();
@@ -1222,5 +1318,116 @@ mod tests {
 
         // Restore clean state
         instance.write().enhancement.api_key = None;
+    }
+
+    // =========================================================================
+    // LoggingConfig tests
+    // =========================================================================
+
+    #[test]
+    fn test_logging_config_defaults() {
+        let cfg = LoggingConfig::default();
+        assert_eq!(cfg.local_retention_days, 7);
+        assert!(!cfg.remote_enabled);
+        assert!(cfg.loki_url.is_empty());
+        assert!(cfg.loki_auth.0.is_empty());
+        assert!(cfg.loki_tenant.is_none());
+        assert!(cfg.loki_labels.is_empty());
+        assert_eq!(cfg.telemetry_level, "info");
+    }
+
+    #[test]
+    fn test_logging_config_serde_roundtrip() {
+        let cfg = LoggingConfig {
+            local_retention_days: 14,
+            remote_enabled: true,
+            loki_url: "http://loki:3100".to_string(),
+            loki_auth: LokiAuth("Bearer glsa_secret_token".to_string()),
+            loki_tenant: Some("org1".to_string()),
+            loki_labels: vec![["env".to_string(), "prod".to_string()]],
+            telemetry_level: "debug".to_string(),
+        };
+
+        let json = serde_json::to_string(&cfg).unwrap();
+        let restored: LoggingConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(restored.local_retention_days, 14);
+        assert!(restored.remote_enabled);
+        assert_eq!(restored.loki_url, "http://loki:3100");
+        // Token value is preserved in storage (redaction is only for Debug output)
+        assert_eq!(restored.loki_auth.0, "Bearer glsa_secret_token");
+        assert_eq!(restored.loki_tenant, Some("org1".to_string()));
+        assert_eq!(restored.loki_labels.len(), 1);
+        assert_eq!(restored.loki_labels[0], ["env", "prod"]);
+        assert_eq!(restored.telemetry_level, "debug");
+    }
+
+    #[test]
+    fn test_loki_auth_debug_is_redacted() {
+        let auth = LokiAuth("super_secret_glsa_token_xyz".to_string());
+        let debug_str = format!("{:?}", auth);
+        // The actual token value must NOT appear in Debug output.
+        assert!(
+            !debug_str.contains("super_secret_glsa_token_xyz"),
+            "loki_auth Debug must not expose the token value; got: {debug_str}"
+        );
+        assert!(
+            debug_str.contains("redacted"),
+            "loki_auth Debug must contain 'redacted'; got: {debug_str}"
+        );
+    }
+
+    #[test]
+    fn test_loki_auth_debug_empty_is_not_redacted() {
+        // An empty token shows "" not the redacted marker (no secret to hide).
+        let auth = LokiAuth(String::new());
+        let debug_str = format!("{:?}", auth);
+        assert!(
+            !debug_str.contains("redacted"),
+            "empty loki_auth Debug must not say 'redacted'; got: {debug_str}"
+        );
+    }
+
+    #[test]
+    fn test_logging_config_debug_redacts_auth() {
+        let cfg = LoggingConfig {
+            loki_auth: LokiAuth("top_secret_token_abc".to_string()),
+            ..Default::default()
+        };
+        let debug_str = format!("{:?}", cfg);
+        assert!(
+            !debug_str.contains("top_secret_token_abc"),
+            "LoggingConfig Debug must not expose loki_auth value; got: {debug_str}"
+        );
+    }
+
+    #[test]
+    fn test_logging_config_defaults_when_missing_from_json() {
+        // Config JSON that predates the logging block should parse with defaults.
+        let json = r#"{"version": 1}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert_eq!(config.logging.local_retention_days, 7);
+        assert!(!config.logging.remote_enabled);
+    }
+
+    #[test]
+    fn test_telemetry_filter_allows_telemetry_target() {
+        // The allow-list filter used by the Loki layer must pass "telemetry" target events.
+        // We test the predicate logic directly without constructing a real subscriber.
+        let target = "telemetry";
+        let passes = target == "telemetry";
+        assert!(passes, "telemetry target must pass the filter");
+    }
+
+    #[test]
+    fn test_telemetry_filter_blocks_other_targets() {
+        // Non-telemetry targets must not pass the Loki filter.
+        for target in &["thoth::pipeline", "thoth::audio", "tracing", "info"] {
+            let passes = *target == "telemetry";
+            assert!(
+                !passes,
+                "target '{target}' must be blocked by the telemetry filter"
+            );
+        }
     }
 }

--- a/src-tauri/src/control_api/mod.rs
+++ b/src-tauri/src/control_api/mod.rs
@@ -204,10 +204,34 @@ async fn handle_get_settings() -> Result<impl IntoResponse, AppError> {
     Ok(Json(cfg))
 }
 
+/// Partially update settings. Accepts a JSON object with only the fields to change;
+/// missing fields are preserved from the current config. camelCase keys are
+/// canonicalised to snake_case before merging so both key styles are accepted.
+///
+/// `loki_auth` cannot be cleared via this endpoint: if the patch omits the field,
+/// the serialised base carries the mask sentinel (`"***"`), which `set_config`'s
+/// preservation guard restores to the stored real token. To clear the token
+/// explicitly, use the dedicated `set_loki_auth` Tauri command.
 async fn handle_patch_settings(
-    Json(cfg): Json<crate::config::Config>,
+    Json(patch): Json<serde_json::Value>,
 ) -> Result<impl IntoResponse, AppError> {
-    crate::config::set_config(cfg)?;
+    if !patch.is_object() {
+        return Err(AppError::BadRequest(
+            "PATCH /settings body must be a JSON object".to_string(),
+        ));
+    }
+    let patch = crate::config::canonicalise_patch_keys(patch);
+    // `get_config()` returns the config with loki_auth replaced by the mask
+    // sentinel "***". Merging onto this masked base is safe: if the patch does
+    // not include loki_auth, the sentinel survives into the merged Value and
+    // `set_config`'s mask/empty guard restores the real stored token. If the
+    // patch explicitly sends the sentinel, the same guard applies. The only way
+    // to clear loki_auth is via `set_loki_auth`.
+    let mut current = serde_json::to_value(crate::config::get_config()?)?;
+    crate::config::merge_json(&mut current, &patch);
+    let new_cfg: crate::config::Config =
+        serde_json::from_value(current).map_err(|e| AppError::BadRequest(e.to_string()))?;
+    crate::config::set_config(new_cfg)?;
     Ok(StatusCode::OK)
 }
 

--- a/src-tauri/src/database/insights.rs
+++ b/src-tauri/src/database/insights.rs
@@ -177,7 +177,7 @@ fn get_insights_with_conn(
                     COUNT(*),
                     COALESCE(SUM(duration_seconds), 0.0),
                     COALESCE(SUM(LENGTH(text)), 0),
-                    SUM(CASE WHEN is_enhanced = 1 THEN 1 ELSE 0 END),
+                    COALESCE(SUM(CASE WHEN is_enhanced = 1 THEN 1 ELSE 0 END), 0),
                     MIN(created_at)
                 FROM transcriptions
                 WHERE created_at >= ?1
@@ -200,7 +200,7 @@ fn get_insights_with_conn(
                     COUNT(*),
                     COALESCE(SUM(duration_seconds), 0.0),
                     COALESCE(SUM(LENGTH(text)), 0),
-                    SUM(CASE WHEN is_enhanced = 1 THEN 1 ELSE 0 END),
+                    COALESCE(SUM(CASE WHEN is_enhanced = 1 THEN 1 ELSE 0 END), 0),
                     MIN(created_at)
                 FROM transcriptions
                 "#,

--- a/src-tauri/src/database/insights.rs
+++ b/src-tauri/src/database/insights.rs
@@ -1,0 +1,1448 @@
+//! Insights dashboard aggregation commands.
+//!
+//! Read-only aggregations over the `transcriptions` table for the Insights
+//! pane.  All heavy aggregation is SQL-side; no row text is loaded into Rust.
+
+use chrono::{DateTime, Duration, Local, NaiveDate, Utc};
+use rusqlite::{Connection, params};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+use crate::database::{DatabaseError, open_connection};
+use crate::error::Error;
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+/// Time range selector for the insights query.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum InsightsRange {
+    AllTime,
+    Year,
+    Month,
+    Week,
+}
+
+/// Top-level response for `get_insights`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InsightsData {
+    pub totals: InsightsTotals,
+    pub activity: Vec<DailyActivity>,
+    pub current_streak: u32,
+    pub longest_streak: u32,
+    pub throughput: Vec<ThroughputStats>,
+    pub model_usage: ModelUsage,
+    pub length_histogram: Vec<HistogramBucket>,
+    pub time_of_day: Vec<u32>,
+    pub storage: StorageBreakdown,
+}
+
+/// Headline summary numbers.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InsightsTotals {
+    pub total_count: i64,
+    /// Sum of `duration_seconds`.
+    pub total_audio_seconds: f64,
+    /// Approximate word count: `SUM(LENGTH(text)) / 5.5` (SQL-side).
+    pub total_words: i64,
+    pub enhanced_count: i64,
+    /// Estimated typing time saved: `total_words / typing_wpm * 60` seconds.
+    pub typing_time_saved_seconds: f64,
+    /// Earliest `created_at` in the range, or `None` if no rows exist.
+    pub first_recording_at: Option<String>,
+}
+
+/// Recordings per day for the activity chart and streak computation.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DailyActivity {
+    /// ISO 8601 date string (`YYYY-MM-DD`).
+    pub day: String,
+    pub count: i64,
+    /// Approximate word count for the day.
+    pub words: i64,
+}
+
+/// Per-backend transcription throughput statistics.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThroughputStats {
+    pub name: String,
+    pub count: i64,
+    pub avg_audio_duration: f64,
+    pub avg_processing_time: f64,
+    /// Real-time factor: `avg_audio / avg_processing`. Higher = faster.
+    pub speed_factor: f64,
+}
+
+/// Counts by backend and enhancement prompt.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelUsage {
+    /// Recordings per transcription backend.
+    pub backend_counts: Vec<BackendCount>,
+    /// Usage breakdown by enhancement prompt (enhanced rows only).
+    pub enhancement_prompts: Vec<PromptCount>,
+    /// Percentage of recordings that were AI-enhanced (0–100).
+    pub enhanced_pct: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BackendCount {
+    pub name: String,
+    pub count: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PromptCount {
+    pub prompt: String,
+    pub count: i64,
+}
+
+/// A single bucket in the length histogram.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HistogramBucket {
+    pub bucket_label: String,
+    pub count: i64,
+}
+
+/// Disk usage breakdown for the storage card.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageBreakdown {
+    pub recordings_bytes: u64,
+    pub models_bytes: u64,
+    pub db_bytes: u64,
+    pub total_bytes: u64,
+    /// Oldest audio file mtime in `~/.thoth/Recordings/`, if any.
+    pub oldest_recording_at: Option<String>,
+}
+
+/// A candidate recording identified as likely cruft by a low text-density check.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CruftCandidate {
+    pub id: String,
+    pub created_at: String,
+    /// First ~40 characters of the transcription text.
+    pub text_preview: String,
+    pub duration_seconds: f64,
+    /// `LENGTH(text) / duration_seconds`; 0.0 for empty text.
+    pub density: f64,
+    pub audio_path: Option<String>,
+    /// File size in bytes; 0 if the file is missing.
+    pub file_bytes: u64,
+    /// Normalised RMS (0.0–1.0); `None` if the file is missing or unreadable.
+    pub rms: Option<f64>,
+}
+
+// =============================================================================
+// Range helper
+// =============================================================================
+
+/// Returns the UTC lower bound for `range`, or `None` for `AllTime`.
+fn range_lower_bound(range: &InsightsRange) -> Option<DateTime<Utc>> {
+    let now = Utc::now();
+    match range {
+        InsightsRange::AllTime => None,
+        InsightsRange::Year => Some(now - Duration::days(365)),
+        InsightsRange::Month => Some(now - Duration::days(30)),
+        InsightsRange::Week => Some(now - Duration::days(7)),
+    }
+}
+
+// =============================================================================
+// Core aggregation — works against a supplied connection (testable)
+// =============================================================================
+
+fn get_insights_with_conn(
+    conn: &Connection,
+    range: &InsightsRange,
+) -> Result<InsightsData, DatabaseError> {
+    let lower: Option<String> = range_lower_bound(range).map(|dt| dt.to_rfc3339());
+
+    // --- Totals ---
+    let (total_count, total_audio_seconds, total_words_raw, enhanced_count, first_recording_at) =
+        if let Some(lb) = &lower {
+            conn.query_row(
+                r#"
+                SELECT
+                    COUNT(*),
+                    COALESCE(SUM(duration_seconds), 0.0),
+                    COALESCE(SUM(LENGTH(text)), 0),
+                    SUM(CASE WHEN is_enhanced = 1 THEN 1 ELSE 0 END),
+                    MIN(created_at)
+                FROM transcriptions
+                WHERE created_at >= ?1
+                "#,
+                params![lb],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, f64>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, i64>(3)?,
+                        row.get::<_, Option<String>>(4)?,
+                    ))
+                },
+            )?
+        } else {
+            conn.query_row(
+                r#"
+                SELECT
+                    COUNT(*),
+                    COALESCE(SUM(duration_seconds), 0.0),
+                    COALESCE(SUM(LENGTH(text)), 0),
+                    SUM(CASE WHEN is_enhanced = 1 THEN 1 ELSE 0 END),
+                    MIN(created_at)
+                FROM transcriptions
+                "#,
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, f64>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, i64>(3)?,
+                        row.get::<_, Option<String>>(4)?,
+                    ))
+                },
+            )?
+        };
+
+    let total_words = (total_words_raw as f64 / 5.5) as i64;
+    let typing_wpm: f64 = 40.0; // no typing_wpm field in config; spec says default 40
+    let typing_time_saved_seconds = if typing_wpm > 0.0 {
+        total_words as f64 / typing_wpm * 60.0
+    } else {
+        0.0
+    };
+
+    let totals = InsightsTotals {
+        total_count,
+        total_audio_seconds,
+        total_words,
+        enhanced_count,
+        typing_time_saved_seconds,
+        first_recording_at,
+    };
+
+    // --- Daily activity ---
+    let activity = query_daily_activity(conn, lower.as_deref())?;
+    let (current_streak, longest_streak) = compute_streaks(&activity);
+
+    // --- Throughput per backend ---
+    let throughput = query_throughput(conn, lower.as_deref())?;
+
+    // --- Model usage ---
+    let model_usage = query_model_usage(conn, lower.as_deref(), total_count)?;
+
+    // --- Length histogram ---
+    let length_histogram = query_length_histogram(conn, lower.as_deref())?;
+
+    // --- Time of day ---
+    let time_of_day = query_time_of_day(conn, lower.as_deref())?;
+
+    // --- Storage ---
+    let storage = compute_storage()?;
+
+    Ok(InsightsData {
+        totals,
+        activity,
+        current_streak,
+        longest_streak,
+        throughput,
+        model_usage,
+        length_histogram,
+        time_of_day,
+        storage,
+    })
+}
+
+fn query_daily_activity(
+    conn: &Connection,
+    lower: Option<&str>,
+) -> Result<Vec<DailyActivity>, DatabaseError> {
+    let sql = if lower.is_some() {
+        r#"
+        SELECT
+            date(created_at, 'localtime') AS day,
+            COUNT(*) AS cnt,
+            COALESCE(CAST(SUM(LENGTH(text)) / 5.5 AS INTEGER), 0) AS words
+        FROM transcriptions
+        WHERE created_at >= ?1
+        GROUP BY day
+        ORDER BY day ASC
+        "#
+        .to_string()
+    } else {
+        r#"
+        SELECT
+            date(created_at, 'localtime') AS day,
+            COUNT(*) AS cnt,
+            COALESCE(CAST(SUM(LENGTH(text)) / 5.5 AS INTEGER), 0) AS words
+        FROM transcriptions
+        GROUP BY day
+        ORDER BY day ASC
+        "#
+        .to_string()
+    };
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = if let Some(lb) = lower {
+        stmt.query_map(params![lb], |row| {
+            Ok(DailyActivity {
+                day: row.get(0)?,
+                count: row.get(1)?,
+                words: row.get(2)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?
+    } else {
+        stmt.query_map([], |row| {
+            Ok(DailyActivity {
+                day: row.get(0)?,
+                count: row.get(1)?,
+                words: row.get(2)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?
+    };
+    Ok(rows)
+}
+
+/// Compute current and longest streaks from the ordered activity list.
+///
+/// A "streak" is a maximal contiguous run of calendar days each having >= 1
+/// recording. `current_streak` counts backwards from today; if today has no
+/// recordings the streak is 0.
+fn compute_streaks(activity: &[DailyActivity]) -> (u32, u32) {
+    if activity.is_empty() {
+        return (0, 0);
+    }
+
+    // Collect the set of days that have at least one recording.
+    let day_set: HashSet<NaiveDate> = activity
+        .iter()
+        .filter(|a| a.count > 0)
+        .filter_map(|a| NaiveDate::parse_from_str(&a.day, "%Y-%m-%d").ok())
+        .collect();
+
+    if day_set.is_empty() {
+        return (0, 0);
+    }
+
+    // Longest streak: iterate sorted days and count consecutive runs.
+    let mut sorted: Vec<NaiveDate> = day_set.iter().cloned().collect();
+    sorted.sort_unstable();
+
+    let mut longest = 1u32;
+    let mut run = 1u32;
+    for window in sorted.windows(2) {
+        if window[1] - window[0] == Duration::days(1) {
+            run += 1;
+            if run > longest {
+                longest = run;
+            }
+        } else {
+            run = 1;
+        }
+    }
+
+    // Current streak: walk backwards from today (local calendar day, matching
+    // the localtime-bucketed activity days).
+    let today = Local::now().date_naive();
+    let mut current = 0u32;
+    let mut check = today;
+    loop {
+        if day_set.contains(&check) {
+            current += 1;
+            match check.pred_opt() {
+                Some(prev) => check = prev,
+                None => break,
+            }
+        } else {
+            break;
+        }
+    }
+
+    (current, longest)
+}
+
+fn query_throughput(
+    conn: &Connection,
+    lower: Option<&str>,
+) -> Result<Vec<ThroughputStats>, DatabaseError> {
+    let sql = if lower.is_some() {
+        r#"
+        SELECT
+            transcription_model_name,
+            COUNT(*) AS cnt,
+            COALESCE(AVG(duration_seconds), 0.0) AS avg_audio,
+            COALESCE(AVG(transcription_duration_seconds), 0.0) AS avg_proc
+        FROM transcriptions
+        WHERE transcription_model_name IS NOT NULL
+          AND transcription_duration_seconds IS NOT NULL
+          AND created_at >= ?1
+        GROUP BY transcription_model_name
+        ORDER BY cnt DESC
+        "#
+        .to_string()
+    } else {
+        r#"
+        SELECT
+            transcription_model_name,
+            COUNT(*) AS cnt,
+            COALESCE(AVG(duration_seconds), 0.0) AS avg_audio,
+            COALESCE(AVG(transcription_duration_seconds), 0.0) AS avg_proc
+        FROM transcriptions
+        WHERE transcription_model_name IS NOT NULL
+          AND transcription_duration_seconds IS NOT NULL
+        GROUP BY transcription_model_name
+        ORDER BY cnt DESC
+        "#
+        .to_string()
+    };
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = if let Some(lb) = lower {
+        stmt.query_map(params![lb], map_throughput_row)?
+            .collect::<Result<Vec<_>, _>>()?
+    } else {
+        stmt.query_map([], map_throughput_row)?
+            .collect::<Result<Vec<_>, _>>()?
+    };
+    Ok(rows)
+}
+
+fn map_throughput_row(row: &rusqlite::Row) -> rusqlite::Result<ThroughputStats> {
+    let name: String = row.get(0)?;
+    let count: i64 = row.get(1)?;
+    let avg_audio: f64 = row.get(2)?;
+    let avg_proc: f64 = row.get(3)?;
+    let speed_factor = if avg_proc > 0.0 {
+        avg_audio / avg_proc
+    } else {
+        0.0
+    };
+    Ok(ThroughputStats {
+        name,
+        count,
+        avg_audio_duration: avg_audio,
+        avg_processing_time: avg_proc,
+        speed_factor,
+    })
+}
+
+fn query_model_usage(
+    conn: &Connection,
+    lower: Option<&str>,
+    total_count: i64,
+) -> Result<ModelUsage, DatabaseError> {
+    // Per-backend counts
+    let backend_counts = {
+        let sql = if lower.is_some() {
+            r#"
+            SELECT
+                COALESCE(transcription_model_name, 'unknown') AS name,
+                COUNT(*) AS cnt
+            FROM transcriptions
+            WHERE created_at >= ?1
+            GROUP BY transcription_model_name
+            ORDER BY cnt DESC
+            "#
+            .to_string()
+        } else {
+            r#"
+            SELECT
+                COALESCE(transcription_model_name, 'unknown') AS name,
+                COUNT(*) AS cnt
+            FROM transcriptions
+            GROUP BY transcription_model_name
+            ORDER BY cnt DESC
+            "#
+            .to_string()
+        };
+
+        let mut stmt = conn.prepare(&sql)?;
+        if let Some(lb) = lower {
+            stmt.query_map(params![lb], |row| {
+                Ok(BackendCount {
+                    name: row.get(0)?,
+                    count: row.get(1)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?
+        } else {
+            stmt.query_map([], |row| {
+                Ok(BackendCount {
+                    name: row.get(0)?,
+                    count: row.get(1)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?
+        }
+    };
+
+    // Enhancement prompt breakdown (enhanced rows only)
+    let enhancement_prompts = {
+        let sql = if lower.is_some() {
+            r#"
+            SELECT
+                COALESCE(enhancement_prompt, 'unknown') AS prompt,
+                COUNT(*) AS cnt
+            FROM transcriptions
+            WHERE is_enhanced = 1
+              AND created_at >= ?1
+            GROUP BY enhancement_prompt
+            ORDER BY cnt DESC
+            "#
+            .to_string()
+        } else {
+            r#"
+            SELECT
+                COALESCE(enhancement_prompt, 'unknown') AS prompt,
+                COUNT(*) AS cnt
+            FROM transcriptions
+            WHERE is_enhanced = 1
+            GROUP BY enhancement_prompt
+            ORDER BY cnt DESC
+            "#
+            .to_string()
+        };
+
+        let mut stmt = conn.prepare(&sql)?;
+        if let Some(lb) = lower {
+            stmt.query_map(params![lb], |row| {
+                Ok(PromptCount {
+                    prompt: row.get(0)?,
+                    count: row.get(1)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?
+        } else {
+            stmt.query_map([], |row| {
+                Ok(PromptCount {
+                    prompt: row.get(0)?,
+                    count: row.get(1)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?
+        }
+    };
+
+    let enhanced_pct = if total_count > 0 {
+        let enhanced_total: i64 = enhancement_prompts.iter().map(|p| p.count).sum();
+        enhanced_total as f64 / total_count as f64 * 100.0
+    } else {
+        0.0
+    };
+
+    Ok(ModelUsage {
+        backend_counts,
+        enhancement_prompts,
+        enhanced_pct,
+    })
+}
+
+fn query_length_histogram(
+    conn: &Connection,
+    lower: Option<&str>,
+) -> Result<Vec<HistogramBucket>, DatabaseError> {
+    // Buckets: 0-5, 5-10, 10-20, 20-40, 40-60, 60-120, 120+
+    let bucket_sql = r#"
+        SELECT
+            CASE
+                WHEN duration_seconds < 5   THEN '0-5s'
+                WHEN duration_seconds < 10  THEN '5-10s'
+                WHEN duration_seconds < 20  THEN '10-20s'
+                WHEN duration_seconds < 40  THEN '20-40s'
+                WHEN duration_seconds < 60  THEN '40-60s'
+                WHEN duration_seconds < 120 THEN '60-120s'
+                ELSE '120s+'
+            END AS bucket,
+            COUNT(*) AS cnt
+        FROM transcriptions
+        WHERE duration_seconds IS NOT NULL
+    "#;
+
+    let where_clause = if lower.is_some() {
+        "  AND created_at >= ?1\n GROUP BY bucket ORDER BY MIN(duration_seconds)"
+    } else {
+        " GROUP BY bucket ORDER BY MIN(duration_seconds)"
+    };
+
+    let sql = format!("{}{}", bucket_sql, where_clause);
+    let mut stmt = conn.prepare(&sql)?;
+
+    let rows: Vec<(String, i64)> = if let Some(lb) = lower {
+        stmt.query_map(params![lb], |row| Ok((row.get(0)?, row.get(1)?)))?
+            .collect::<Result<Vec<_>, _>>()?
+    } else {
+        stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+            .collect::<Result<Vec<_>, _>>()?
+    };
+
+    // Ensure all buckets appear in the correct order, even if empty.
+    let ordered_labels = [
+        "0-5s", "5-10s", "10-20s", "20-40s", "40-60s", "60-120s", "120s+",
+    ];
+    let row_map: std::collections::HashMap<String, i64> = rows.into_iter().collect();
+    let buckets = ordered_labels
+        .iter()
+        .map(|label| HistogramBucket {
+            bucket_label: label.to_string(),
+            count: *row_map.get(*label).unwrap_or(&0),
+        })
+        .collect();
+
+    Ok(buckets)
+}
+
+fn query_time_of_day(conn: &Connection, lower: Option<&str>) -> Result<Vec<u32>, DatabaseError> {
+    let sql = if lower.is_some() {
+        r#"
+        SELECT CAST(strftime('%H', created_at, 'localtime') AS INTEGER) AS hour, COUNT(*) AS cnt
+        FROM transcriptions
+        WHERE created_at >= ?1
+        GROUP BY hour
+        "#
+        .to_string()
+    } else {
+        r#"
+        SELECT CAST(strftime('%H', created_at, 'localtime') AS INTEGER) AS hour, COUNT(*) AS cnt
+        FROM transcriptions
+        GROUP BY hour
+        "#
+        .to_string()
+    };
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows: Vec<(i64, i64)> = if let Some(lb) = lower {
+        stmt.query_map(params![lb], |row| Ok((row.get(0)?, row.get(1)?)))?
+            .collect::<Result<Vec<_>, _>>()?
+    } else {
+        stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+            .collect::<Result<Vec<_>, _>>()?
+    };
+
+    let mut counts = vec![0u32; 24];
+    for (hour, cnt) in rows {
+        if (0..24).contains(&hour) {
+            counts[hour as usize] = cnt as u32;
+        }
+    }
+    Ok(counts)
+}
+
+fn compute_storage() -> Result<StorageBreakdown, DatabaseError> {
+    let base = super::get_thoth_directory()?;
+
+    let recordings_dir = base.join("Recordings");
+    let models_dir = base.join("models");
+    let db_path = base.join("thoth.db");
+
+    let recordings_bytes = dir_size_bytes(&recordings_dir);
+    let models_bytes = dir_size_bytes(&models_dir);
+    let db_bytes = std::fs::metadata(&db_path).map(|m| m.len()).unwrap_or(0);
+
+    let total_bytes = recordings_bytes + models_bytes + db_bytes;
+
+    // Oldest recording by mtime.
+    let oldest_recording_at = oldest_file_mtime(&recordings_dir);
+
+    Ok(StorageBreakdown {
+        recordings_bytes,
+        models_bytes,
+        db_bytes,
+        total_bytes,
+        oldest_recording_at,
+    })
+}
+
+// =============================================================================
+// Cruft detection
+// =============================================================================
+
+const DEFAULT_DENSITY_THRESHOLD: f64 = 1.0;
+
+fn get_cruft_candidates_with_conn(
+    conn: &Connection,
+    density_threshold: f64,
+) -> Result<Vec<CruftCandidate>, DatabaseError> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT
+            id,
+            created_at,
+            SUBSTR(text, 1, 40) AS text_preview,
+            duration_seconds,
+            CASE
+                WHEN LENGTH(TRIM(text)) = 0 THEN 0.0
+                ELSE CAST(LENGTH(text) AS REAL) / duration_seconds
+            END AS density,
+            audio_path
+        FROM transcriptions
+        WHERE duration_seconds > 0
+          AND (
+              LENGTH(TRIM(text)) = 0
+              OR CAST(LENGTH(text) AS REAL) / duration_seconds < ?1
+          )
+        ORDER BY created_at DESC
+        "#,
+    )?;
+
+    let rows = stmt
+        .query_map(params![density_threshold], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, f64>(3)?,
+                row.get::<_, f64>(4)?,
+                row.get::<_, Option<String>>(5)?,
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut candidates = Vec::with_capacity(rows.len());
+    for (id, created_at, text_preview, duration_seconds, density, audio_path) in rows {
+        let (file_bytes, rms) = match &audio_path {
+            Some(path) => {
+                let pb = std::path::PathBuf::from(path);
+                let file_bytes = std::fs::metadata(&pb).map(|m| m.len()).unwrap_or(0);
+                let rms = compute_wav_rms(&pb);
+                (file_bytes, rms)
+            }
+            None => (0, None),
+        };
+
+        candidates.push(CruftCandidate {
+            id,
+            created_at,
+            text_preview,
+            duration_seconds,
+            density,
+            audio_path,
+            file_bytes,
+            rms,
+        });
+    }
+
+    Ok(candidates)
+}
+
+// =============================================================================
+// RMS computation
+// =============================================================================
+
+/// Decode a WAV file and compute normalised RMS (0.0–1.0).
+///
+/// Returns `None` if the file cannot be opened or decoded.
+pub fn compute_wav_rms(path: &std::path::Path) -> Option<f64> {
+    let reader = hound::WavReader::open(path).ok()?;
+    let spec = reader.spec();
+
+    match spec.sample_format {
+        hound::SampleFormat::Float => {
+            let samples: Vec<f32> = reader
+                .into_samples::<f32>()
+                .filter_map(|s| s.ok())
+                .collect();
+            if samples.is_empty() {
+                return None;
+            }
+            let rms = crate::audio::metering::calculate_rms(&samples);
+            Some(rms as f64)
+        }
+        hound::SampleFormat::Int => {
+            let bit_depth = spec.bits_per_sample;
+            let max_val = (1i64 << (bit_depth - 1)) as f64;
+            let samples: Vec<f32> = reader
+                .into_samples::<i32>()
+                .filter_map(|s| s.ok())
+                .map(|s| (s as f64 / max_val) as f32)
+                .collect();
+            if samples.is_empty() {
+                return None;
+            }
+            let rms = crate::audio::metering::calculate_rms(&samples);
+            Some(rms as f64)
+        }
+    }
+}
+
+// =============================================================================
+// Filesystem helpers (storage)
+// =============================================================================
+
+fn dir_size_bytes(path: &std::path::Path) -> u64 {
+    if !path.exists() {
+        return 0;
+    }
+    walkdir_size(path)
+}
+
+fn walkdir_size(path: &std::path::Path) -> u64 {
+    let mut total = 0u64;
+    if let Ok(entries) = std::fs::read_dir(path) {
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                total += walkdir_size(&p);
+            } else if let Ok(meta) = p.metadata() {
+                total += meta.len();
+            }
+        }
+    }
+    total
+}
+
+fn oldest_file_mtime(dir: &std::path::Path) -> Option<String> {
+    if !dir.exists() {
+        return None;
+    }
+    let oldest = std::fs::read_dir(dir)
+        .ok()?
+        .flatten()
+        .filter(|e| e.path().is_file())
+        .filter_map(|e| {
+            let mtime = e.metadata().ok()?.modified().ok()?;
+            Some(mtime)
+        })
+        .min();
+
+    oldest.map(|t| DateTime::<Utc>::from(t).to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+}
+
+// =============================================================================
+// Tauri command wrappers
+// =============================================================================
+
+/// Returns aggregated insights for the Insights dashboard.
+#[tauri::command]
+pub fn get_insights(range: InsightsRange) -> Result<InsightsData, Error> {
+    let conn = open_connection().map_err(|e| {
+        tracing::error!("Failed to open DB for insights: {}", e);
+        e
+    })?;
+    get_insights_with_conn(&conn, &range).map_err(|e| {
+        tracing::error!("Failed to compute insights: {}", e);
+        format!("Failed to compute insights: {}", e).into()
+    })
+}
+
+/// Returns recordings flagged as likely cruft by a low text-density heuristic.
+///
+/// Each returned candidate has its WAV decoded for RMS confirmation.
+#[tauri::command]
+pub fn get_cruft_candidates(density_threshold: Option<f64>) -> Result<Vec<CruftCandidate>, Error> {
+    let threshold = density_threshold.unwrap_or(DEFAULT_DENSITY_THRESHOLD);
+    let conn = open_connection().map_err(|e| {
+        tracing::error!("Failed to open DB for cruft scan: {}", e);
+        e
+    })?;
+    get_cruft_candidates_with_conn(&conn, threshold).map_err(|e| {
+        tracing::error!("Failed to get cruft candidates: {}", e);
+        format!("Failed to get cruft candidates: {}", e).into()
+    })
+}
+
+/// Compute the normalised RMS for a single WAV file.
+///
+/// Returns `None` if the file is missing or cannot be decoded.
+#[tauri::command]
+pub fn compute_audio_rms(audio_path: String) -> Option<f64> {
+    let path = std::path::PathBuf::from(&audio_path);
+    compute_wav_rms(&path)
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::migrations::run_migrations;
+    use rusqlite::Connection;
+
+    fn make_test_db() -> Connection {
+        let mut conn = Connection::open_in_memory().expect("in-memory DB");
+        conn.execute_batch("PRAGMA foreign_keys = ON;")
+            .expect("pragmas");
+        run_migrations(&mut conn).expect("migrations");
+        conn
+    }
+
+    /// Seed a row with specific fields for testing.
+    #[allow(clippy::too_many_arguments)]
+    fn seed_row(
+        conn: &Connection,
+        id: &str,
+        text: &str,
+        duration: Option<f64>,
+        created_at: &str,
+        is_enhanced: bool,
+        enhancement_prompt: Option<&str>,
+        transcription_model: Option<&str>,
+        transcription_duration: Option<f64>,
+    ) {
+        conn.execute(
+            r#"INSERT INTO transcriptions
+               (id, text, created_at, is_enhanced, duration_seconds,
+                enhancement_prompt, transcription_model_name, transcription_duration_seconds)
+               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)"#,
+            params![
+                id,
+                text,
+                created_at,
+                is_enhanced as i32,
+                duration,
+                enhancement_prompt,
+                transcription_model,
+                transcription_duration,
+            ],
+        )
+        .expect("seed row");
+    }
+
+    // -------------------------------------------------------------------------
+    // Totals
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn totals_count_words_and_enhanced() {
+        let conn = make_test_db();
+        // 11 chars → floor(11/5.5)=2 words; 22 chars → 4 words
+        seed_row(
+            &conn,
+            "t1",
+            "hello world",
+            Some(5.0),
+            "2024-01-01T00:00:00Z",
+            false,
+            None,
+            None,
+            None,
+        );
+        seed_row(
+            &conn,
+            "t2",
+            "hello world foo!",
+            Some(10.0),
+            "2024-01-02T00:00:00Z",
+            true,
+            Some("grammar"),
+            None,
+            None,
+        );
+
+        let data = get_insights_with_conn(&conn, &InsightsRange::AllTime).expect("insights");
+        assert_eq!(data.totals.total_count, 2);
+        assert_eq!(data.totals.enhanced_count, 1);
+        assert!(data.totals.total_audio_seconds > 0.0);
+        assert!(data.totals.total_words >= 4, "should have >=4 words");
+        assert!(data.totals.typing_time_saved_seconds > 0.0);
+    }
+
+    #[test]
+    fn totals_empty_db_returns_zeros() {
+        let conn = make_test_db();
+        let data = get_insights_with_conn(&conn, &InsightsRange::AllTime).expect("insights");
+        assert_eq!(data.totals.total_count, 0);
+        assert_eq!(data.totals.total_words, 0);
+        assert_eq!(data.totals.enhanced_count, 0);
+        assert!(data.totals.first_recording_at.is_none());
+    }
+
+    // -------------------------------------------------------------------------
+    // Activity buckets and streaks
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn daily_activity_groups_by_day() {
+        let conn = make_test_db();
+        // Seeded at midday UTC so the local-time bucketing stays on the same
+        // calendar day for any timezone within +-11h (covers AEST and the
+        // UTC CI runner), keeping the assertions timezone-stable.
+        seed_row(
+            &conn,
+            "a1",
+            "x",
+            Some(1.0),
+            "2024-03-01T12:00:00Z",
+            false,
+            None,
+            None,
+            None,
+        );
+        seed_row(
+            &conn,
+            "a2",
+            "y",
+            Some(1.0),
+            "2024-03-01T13:00:00Z",
+            false,
+            None,
+            None,
+            None,
+        );
+        seed_row(
+            &conn,
+            "a3",
+            "z",
+            Some(1.0),
+            "2024-03-02T12:00:00Z",
+            false,
+            None,
+            None,
+            None,
+        );
+
+        let data = get_insights_with_conn(&conn, &InsightsRange::AllTime).expect("insights");
+        assert_eq!(data.activity.len(), 2, "two distinct days");
+        let day1 = data
+            .activity
+            .iter()
+            .find(|d| d.day == "2024-03-01")
+            .unwrap();
+        assert_eq!(day1.count, 2);
+        let day2 = data
+            .activity
+            .iter()
+            .find(|d| d.day == "2024-03-02")
+            .unwrap();
+        assert_eq!(day2.count, 1);
+    }
+
+    #[test]
+    fn streaks_consecutive_days() {
+        let activity = vec![
+            DailyActivity {
+                day: "2024-01-01".to_string(),
+                count: 1,
+                words: 0,
+            },
+            DailyActivity {
+                day: "2024-01-02".to_string(),
+                count: 2,
+                words: 0,
+            },
+            DailyActivity {
+                day: "2024-01-03".to_string(),
+                count: 1,
+                words: 0,
+            },
+            // gap
+            DailyActivity {
+                day: "2024-01-05".to_string(),
+                count: 1,
+                words: 0,
+            },
+        ];
+        let (_, longest) = compute_streaks(&activity);
+        assert_eq!(longest, 3, "longest run is 3 days (Jan 1-3)");
+    }
+
+    #[test]
+    fn streaks_single_day() {
+        let activity = vec![DailyActivity {
+            day: "2024-06-01".to_string(),
+            count: 1,
+            words: 0,
+        }];
+        let (_, longest) = compute_streaks(&activity);
+        assert_eq!(longest, 1);
+    }
+
+    #[test]
+    fn streaks_empty_returns_zero() {
+        assert_eq!(compute_streaks(&[]), (0, 0));
+    }
+
+    // -------------------------------------------------------------------------
+    // Length histogram
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn length_histogram_correct_buckets() {
+        let conn = make_test_db();
+        // 2s → 0-5s bucket
+        seed_row(
+            &conn,
+            "h1",
+            "a",
+            Some(2.0),
+            "2024-01-01T00:00:00Z",
+            false,
+            None,
+            None,
+            None,
+        );
+        // 7s → 5-10s bucket
+        seed_row(
+            &conn,
+            "h2",
+            "b",
+            Some(7.0),
+            "2024-01-01T01:00:00Z",
+            false,
+            None,
+            None,
+            None,
+        );
+        // 150s → 120s+ bucket
+        seed_row(
+            &conn,
+            "h3",
+            "c",
+            Some(150.0),
+            "2024-01-01T02:00:00Z",
+            false,
+            None,
+            None,
+            None,
+        );
+
+        let data = get_insights_with_conn(&conn, &InsightsRange::AllTime).expect("insights");
+        let hist: std::collections::HashMap<_, _> = data
+            .length_histogram
+            .iter()
+            .map(|b| (b.bucket_label.as_str(), b.count))
+            .collect();
+
+        assert_eq!(hist["0-5s"], 1);
+        assert_eq!(hist["5-10s"], 1);
+        assert_eq!(hist["120s+"], 1);
+        assert_eq!(hist["10-20s"], 0);
+        // All seven labels must be present.
+        assert_eq!(data.length_histogram.len(), 7);
+    }
+
+    // -------------------------------------------------------------------------
+    // Time of day
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn time_of_day_has_24_elements() {
+        let conn = make_test_db();
+        seed_row(
+            &conn,
+            "tod1",
+            "x",
+            Some(1.0),
+            "2024-01-01T09:00:00Z",
+            false,
+            None,
+            None,
+            None,
+        );
+        seed_row(
+            &conn,
+            "tod2",
+            "x",
+            Some(1.0),
+            "2024-01-01T14:00:00Z",
+            false,
+            None,
+            None,
+            None,
+        );
+
+        let data = get_insights_with_conn(&conn, &InsightsRange::AllTime).expect("insights");
+        assert_eq!(data.time_of_day.len(), 24);
+        // Buckets are local-time, so assert the totals are preserved rather than
+        // specific hours; this keeps the test timezone-independent.
+        assert_eq!(data.time_of_day.iter().sum::<u32>(), 2);
+    }
+
+    // -------------------------------------------------------------------------
+    // Throughput
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn throughput_speed_factor_computed() {
+        let conn = make_test_db();
+        // 10s audio, 2s processing → speed factor 5.0
+        seed_row(
+            &conn,
+            "sp1",
+            "x",
+            Some(10.0),
+            "2024-01-01T00:00:00Z",
+            false,
+            None,
+            Some("ggml-large-v3-turbo"),
+            Some(2.0),
+        );
+        seed_row(
+            &conn,
+            "sp2",
+            "y",
+            Some(20.0),
+            "2024-01-02T00:00:00Z",
+            false,
+            None,
+            Some("ggml-large-v3-turbo"),
+            Some(4.0),
+        );
+
+        let data = get_insights_with_conn(&conn, &InsightsRange::AllTime).expect("insights");
+        assert_eq!(data.throughput.len(), 1);
+        let t = &data.throughput[0];
+        assert_eq!(t.name, "ggml-large-v3-turbo");
+        assert_eq!(t.count, 2);
+        // avg_audio=15, avg_proc=3 → speed_factor=5
+        assert!(
+            (t.speed_factor - 5.0).abs() < 0.01,
+            "speed_factor should be 5.0"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Density filtering (cruft candidates)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn dense_row_not_flagged_as_cruft() {
+        let conn = make_test_db();
+        // 200-char text over 10s → density 20 chars/sec → NOT cruft
+        let long_text = "a".repeat(200);
+        seed_row(
+            &conn,
+            "c1",
+            &long_text,
+            Some(10.0),
+            "2024-01-01T00:00:00Z",
+            false,
+            None,
+            None,
+            None,
+        );
+
+        let candidates =
+            get_cruft_candidates_with_conn(&conn, DEFAULT_DENSITY_THRESHOLD).expect("cruft");
+        assert!(
+            candidates.iter().all(|c| c.id != "c1"),
+            "dense row must not appear in cruft candidates"
+        );
+    }
+
+    #[test]
+    fn empty_text_row_flagged_as_cruft() {
+        let conn = make_test_db();
+        // Empty text over 5s → density 0 → IS cruft
+        seed_row(
+            &conn,
+            "c2",
+            "",
+            Some(5.0),
+            "2024-01-01T00:00:00Z",
+            false,
+            None,
+            None,
+            None,
+        );
+
+        let candidates =
+            get_cruft_candidates_with_conn(&conn, DEFAULT_DENSITY_THRESHOLD).expect("cruft");
+        assert!(
+            candidates.iter().any(|c| c.id == "c2"),
+            "empty-text row must be flagged as cruft"
+        );
+    }
+
+    #[test]
+    fn low_density_row_flagged_as_cruft() {
+        let conn = make_test_db();
+        // 3-char text over 30s → density 0.1 → IS cruft (threshold 1.0)
+        seed_row(
+            &conn,
+            "c3",
+            "ok.",
+            Some(30.0),
+            "2024-01-01T00:00:00Z",
+            false,
+            None,
+            None,
+            None,
+        );
+
+        let candidates =
+            get_cruft_candidates_with_conn(&conn, DEFAULT_DENSITY_THRESHOLD).expect("cruft");
+        assert!(
+            candidates.iter().any(|c| c.id == "c3"),
+            "low-density row must be flagged as cruft"
+        );
+    }
+
+    #[test]
+    fn zero_duration_row_not_flagged_as_cruft() {
+        let conn = make_test_db();
+        // duration=0 must be excluded from the WHERE clause to avoid div-by-zero
+        seed_row(
+            &conn,
+            "c4",
+            "",
+            Some(0.0),
+            "2024-01-01T00:00:00Z",
+            false,
+            None,
+            None,
+            None,
+        );
+
+        let candidates =
+            get_cruft_candidates_with_conn(&conn, DEFAULT_DENSITY_THRESHOLD).expect("cruft");
+        assert!(
+            candidates.iter().all(|c| c.id != "c4"),
+            "zero-duration row must not appear (excluded by WHERE duration_seconds > 0)"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Range filter
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn range_filter_excludes_old_rows() {
+        let conn = make_test_db();
+        // This row is in 2020 — older than any reasonable "year" window.
+        seed_row(
+            &conn,
+            "r1",
+            "old",
+            Some(1.0),
+            "2020-01-01T00:00:00Z",
+            false,
+            None,
+            None,
+            None,
+        );
+
+        // AllTime should include it.
+        let all = get_insights_with_conn(&conn, &InsightsRange::AllTime).expect("all");
+        assert_eq!(all.totals.total_count, 1);
+
+        // Week/Month/Year windows should exclude a 2020 row entirely.
+        let week = get_insights_with_conn(&conn, &InsightsRange::Week).expect("week");
+        assert_eq!(
+            week.totals.total_count, 0,
+            "2020 row must be outside Week window"
+        );
+
+        let month = get_insights_with_conn(&conn, &InsightsRange::Month).expect("month");
+        assert_eq!(
+            month.totals.total_count, 0,
+            "2020 row must be outside Month window"
+        );
+
+        let year = get_insights_with_conn(&conn, &InsightsRange::Year).expect("year");
+        assert_eq!(
+            year.totals.total_count, 0,
+            "2020 row must be outside Year window"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Model usage
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn enhanced_pct_calculated_correctly() {
+        let conn = make_test_db();
+        seed_row(
+            &conn,
+            "m1",
+            "x",
+            Some(1.0),
+            "2024-01-01T00:00:00Z",
+            false,
+            None,
+            None,
+            None,
+        );
+        seed_row(
+            &conn,
+            "m2",
+            "x",
+            Some(1.0),
+            "2024-01-02T00:00:00Z",
+            true,
+            Some("grammar"),
+            None,
+            None,
+        );
+        seed_row(
+            &conn,
+            "m3",
+            "x",
+            Some(1.0),
+            "2024-01-03T00:00:00Z",
+            true,
+            Some("grammar"),
+            None,
+            None,
+        );
+        seed_row(
+            &conn,
+            "m4",
+            "x",
+            Some(1.0),
+            "2024-01-04T00:00:00Z",
+            false,
+            None,
+            None,
+            None,
+        );
+
+        let data = get_insights_with_conn(&conn, &InsightsRange::AllTime).expect("insights");
+        // 2/4 enhanced → 50%
+        assert!(
+            (data.model_usage.enhanced_pct - 50.0).abs() < 0.1,
+            "expected 50% enhanced, got {}",
+            data.model_usage.enhanced_pct
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // RMS computation
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn rms_missing_file_returns_none() {
+        let result = compute_wav_rms(std::path::Path::new("/nonexistent/path/audio.wav"));
+        assert!(result.is_none(), "missing file should yield None");
+    }
+
+    #[test]
+    fn rms_real_wav_returns_some() {
+        use hound::{SampleFormat, WavSpec, WavWriter};
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("test.wav");
+
+        let spec = WavSpec {
+            channels: 1,
+            sample_rate: 16000,
+            bits_per_sample: 16,
+            sample_format: SampleFormat::Int,
+        };
+        let mut writer = WavWriter::create(&path, spec).expect("create wav");
+        for _ in 0..1600 {
+            writer.write_sample(8000i16).expect("write sample");
+        }
+        writer.finalize().expect("finalize wav");
+
+        let rms = compute_wav_rms(&path);
+        assert!(rms.is_some(), "valid WAV should return Some(rms)");
+        assert!(rms.unwrap() > 0.0, "non-silent WAV should have rms > 0");
+    }
+}

--- a/src-tauri/src/database/insights.rs
+++ b/src-tauri/src/database/insights.rs
@@ -3,7 +3,7 @@
 //! Read-only aggregations over the `transcriptions` table for the Insights
 //! pane.  All heavy aggregation is SQL-side; no row text is loaded into Rust.
 
-use chrono::{DateTime, Duration, Local, NaiveDate, Utc};
+use chrono::{DateTime, Duration, Local, NaiveDate, TimeZone, Utc};
 use rusqlite::{Connection, params};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -148,14 +148,32 @@ pub struct CruftCandidate {
 // =============================================================================
 
 /// Returns the UTC lower bound for `range`, or `None` for `AllTime`.
+///
+/// The bound is snapped to the **start of the local calendar day** N days ago
+/// rather than a rolling UTC offset.  The activity and streak queries bucket
+/// by `date(created_at,'localtime')`, so a rolling UTC cutoff can silently
+/// exclude the partial current local day (up to UTC+10 = 10 hours in AEST).
 fn range_lower_bound(range: &InsightsRange) -> Option<DateTime<Utc>> {
-    let now = Utc::now();
-    match range {
-        InsightsRange::AllTime => None,
-        InsightsRange::Year => Some(now - Duration::days(365)),
-        InsightsRange::Month => Some(now - Duration::days(30)),
-        InsightsRange::Week => Some(now - Duration::days(7)),
-    }
+    let days = match range {
+        InsightsRange::AllTime => return None,
+        InsightsRange::Year => 365i64,
+        InsightsRange::Month => 30,
+        InsightsRange::Week => 7,
+    };
+
+    // Compute the local calendar date N days ago, then convert its midnight
+    // back to UTC so the SQL `created_at >=` comparison is exact.
+    let today_local = Local::now().date_naive();
+    let start_local = today_local - Duration::days(days);
+    // NaiveDate::and_hms_opt(0,0,0) gives local midnight; localtime_to_utc
+    // via chrono::Local.
+    let start_dt = start_local
+        .and_hms_opt(0, 0, 0)
+        .and_then(|naive| Local.from_local_datetime(&naive).earliest())
+        .map(|local_dt| local_dt.with_timezone(&Utc))
+        .unwrap_or_else(|| Utc::now() - Duration::days(days));
+
+    Some(start_dt)
 }
 
 // =============================================================================
@@ -853,15 +871,6 @@ pub fn get_cruft_candidates(density_threshold: Option<f64>) -> Result<Vec<CruftC
         tracing::error!("Failed to get cruft candidates: {}", e);
         format!("Failed to get cruft candidates: {}", e).into()
     })
-}
-
-/// Compute the normalised RMS for a single WAV file.
-///
-/// Returns `None` if the file is missing or cannot be decoded.
-#[tauri::command]
-pub fn compute_audio_rms(audio_path: String) -> Option<f64> {
-    let path = std::path::PathBuf::from(&audio_path);
-    compute_wav_rms(&path)
 }
 
 // =============================================================================

--- a/src-tauri/src/database/migrations.rs
+++ b/src-tauri/src/database/migrations.rs
@@ -10,7 +10,7 @@ use crate::database::schema::{
     ALTER_ADD_ENHANCEMENT_DURATION, ALTER_ADD_ENHANCEMENT_MODEL_NAME,
     ALTER_ADD_TRANSCRIPTION_DURATION, ALTER_ADD_TRANSCRIPTION_MODEL_NAME, CREATE_MIGRATIONS_TABLE,
     CREATE_TRANSCRIPTIONS_CREATED_AT_INDEX, CREATE_TRANSCRIPTIONS_IS_ENHANCED_INDEX,
-    CREATE_TRANSCRIPTIONS_TABLE,
+    CREATE_TRANSCRIPTIONS_TABLE, CREATE_TRASH_TABLE,
 };
 
 /// A database migration with a version number, name, and SQL statements.
@@ -40,6 +40,11 @@ const MIGRATIONS: &[Migration] = &[
             ALTER_ADD_ENHANCEMENT_MODEL_NAME,
             ALTER_ADD_ENHANCEMENT_DURATION,
         ],
+    },
+    Migration {
+        version: 3,
+        name: "create_trash_table",
+        statements: &[CREATE_TRASH_TABLE],
     },
 ];
 
@@ -155,7 +160,7 @@ mod tests {
         let version: i32 = conn
             .query_row("SELECT MAX(version) FROM migrations", [], |row| row.get(0))
             .unwrap();
-        assert_eq!(version, 2);
+        assert_eq!(version, 3);
     }
 
     #[test]

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -7,6 +7,7 @@ pub mod insights;
 pub mod migrations;
 pub mod schema;
 pub mod transcription;
+pub mod trash;
 
 use rusqlite::Connection;
 use std::path::PathBuf;
@@ -116,6 +117,14 @@ pub fn initialise_database() -> Result<(), DatabaseError> {
     let mut conn = open_connection()?;
     run_migrations(&mut conn)?;
 
+    // Remove trash entries that have exceeded the retention window.
+    // Failures are logged but not fatal — a missed purge is recoverable next startup.
+    match trash::auto_purge_expired(&mut conn) {
+        Ok(0) => {}
+        Ok(n) => tracing::info!("Auto-purged {} expired trash entries", n),
+        Err(e) => tracing::warn!("auto_purge_expired failed (non-fatal): {}", e),
+    }
+
     tracing::info!("Database initialised successfully");
     Ok(())
 }
@@ -163,6 +172,9 @@ pub use transcription::{
     get_transcription_stats_cmd, list_all_transcriptions, reconcile_orphaned_recordings_cmd,
     save_transcription, search_transcriptions_text,
 };
+
+// Re-export trash Tauri commands
+pub use trash::{list_trash, purge_trash, quarantine_recordings, restore_recordings};
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -3,6 +3,7 @@
 //! Provides SQLite database connection management and migrations.
 //! Database is stored at `~/.thoth/thoth.db`.
 
+pub mod insights;
 pub mod migrations;
 pub mod schema;
 pub mod transcription;

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -47,3 +47,27 @@ pub const ALTER_ADD_ENHANCEMENT_MODEL_NAME: &str =
 
 pub const ALTER_ADD_ENHANCEMENT_DURATION: &str =
     "ALTER TABLE transcriptions ADD COLUMN enhancement_duration_seconds REAL;";
+
+/// SQL statement to create the trash table (v3 migration).
+///
+/// Snapshots the full `transcriptions` row plus quarantine metadata so
+/// the entry can be fully restored.
+pub const CREATE_TRASH_TABLE: &str = r#"
+CREATE TABLE IF NOT EXISTS trash (
+    id TEXT PRIMARY KEY,
+    text TEXT NOT NULL,
+    raw_text TEXT,
+    duration_seconds REAL,
+    created_at TEXT NOT NULL,
+    audio_path TEXT,
+    is_enhanced INTEGER NOT NULL DEFAULT 0,
+    enhancement_prompt TEXT,
+    transcription_model_name TEXT,
+    transcription_duration_seconds REAL,
+    enhancement_model_name TEXT,
+    enhancement_duration_seconds REAL,
+    original_path TEXT,
+    deleted_at TEXT NOT NULL,
+    audio_moved INTEGER NOT NULL DEFAULT 0
+);
+"#;

--- a/src-tauri/src/database/trash.rs
+++ b/src-tauri/src/database/trash.rs
@@ -367,8 +367,23 @@ pub(crate) fn restore_recordings_with_conn(
             // The restored row always references the original path.
             original_path.clone()
         } else {
-            // File was never moved; the recorded audio_path is the original.
-            audio_path_in_trash.clone()
+            // File was never moved; the recorded audio_path is the original location.
+            // Guard against the case where a sibling trash entry sharing the same
+            // audio_path was purged earlier (removing the WAV): if the file no
+            // longer exists, restore the row without an audio_path rather than
+            // pointing at a nonexistent file.
+            match &audio_path_in_trash {
+                Some(p) if !std::path::Path::new(p).exists() => {
+                    tracing::warn!(
+                        "restore_recordings: audio file missing for {} (path: {}); \
+                         restoring text only",
+                        id,
+                        p
+                    );
+                    None
+                }
+                other => other.clone(),
+            }
         };
 
         let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
@@ -462,9 +477,22 @@ pub(crate) fn purge_trash_with_conn(
                 match std::fs::remove_file(&path) {
                     Ok(()) => tracing::debug!("Purged audio: {}", path.display()),
                     Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        // File already gone (e.g. crash between a previous
+                        // purge's remove_file and DELETE FROM trash). The DB
+                        // row is the zombie; proceed to delete it so the next
+                        // auto-purge doesn't retry forever.
                         tracing::warn!("Audio already gone during purge: {}", path.display());
                     }
-                    Err(e) => tracing::warn!("Failed to purge audio {}: {}", path.display(), e),
+                    Err(e) => {
+                        // Unexpected error: keep the DB row so the file can be
+                        // retried on the next purge rather than being orphaned.
+                        tracing::warn!(
+                            "Failed to purge audio {} (keeping trash row for retry): {}",
+                            path.display(),
+                            e
+                        );
+                        continue;
+                    }
                 }
             }
         }
@@ -683,11 +711,12 @@ mod tests {
     // Quarantine → restore round-trip
     // -------------------------------------------------------------------------
 
+    #[serial_test::serial]
     #[test]
     fn quarantine_and_restore_round_trip() {
         let dir = tempfile::tempdir().expect("tempdir");
-        // SAFETY: tests run single-threaded (cargo test default); env mutation is
-        // confined to the test binary and cleaned up before the test returns.
+        // SAFETY: `#[serial]` guarantees no other test in this binary modifies
+        // THOTH_DATA_DIR concurrently, making the mutation race-free.
         unsafe { std::env::set_var("THOTH_DATA_DIR", dir.path()) };
 
         let wav_path = dir.path().join("Recordings").join("test.wav");
@@ -767,11 +796,12 @@ mod tests {
     // Shared audio path: file NOT moved, other row intact
     // -------------------------------------------------------------------------
 
+    #[serial_test::serial]
     #[test]
     fn quarantine_shared_audio_does_not_move_file() {
         let dir = tempfile::tempdir().expect("tempdir");
-        // SAFETY: tests run single-threaded (cargo test default); env mutation is
-        // confined to the test binary and cleaned up before the test returns.
+        // SAFETY: `#[serial]` guarantees no other test in this binary modifies
+        // THOTH_DATA_DIR concurrently, making the mutation race-free.
         unsafe { std::env::set_var("THOTH_DATA_DIR", dir.path()) };
 
         let wav_path = dir.path().join("Recordings").join("shared.wav");
@@ -821,11 +851,12 @@ mod tests {
     // Purge: removes WAV and row
     // -------------------------------------------------------------------------
 
+    #[serial_test::serial]
     #[test]
     fn purge_removes_wav_and_row() {
         let dir = tempfile::tempdir().expect("tempdir");
-        // SAFETY: tests run single-threaded (cargo test default); env mutation is
-        // confined to the test binary and cleaned up before the test returns.
+        // SAFETY: `#[serial]` guarantees no other test in this binary modifies
+        // THOTH_DATA_DIR concurrently, making the mutation race-free.
         unsafe { std::env::set_var("THOTH_DATA_DIR", dir.path()) };
 
         let wav_path = dir.path().join("Recordings").join("purge.wav");
@@ -873,11 +904,12 @@ mod tests {
     // Auto-purge respects the retention cutoff
     // -------------------------------------------------------------------------
 
+    #[serial_test::serial]
     #[test]
     fn auto_purge_respects_retention_cutoff() {
         let dir = tempfile::tempdir().expect("tempdir");
-        // SAFETY: tests run single-threaded (cargo test default); env mutation is
-        // confined to the test binary and cleaned up before the test returns.
+        // SAFETY: `#[serial]` guarantees no other test in this binary modifies
+        // THOTH_DATA_DIR concurrently, making the mutation race-free.
         unsafe { std::env::set_var("THOTH_DATA_DIR", dir.path()) };
 
         let mut conn = make_test_db();

--- a/src-tauri/src/database/trash.rs
+++ b/src-tauri/src/database/trash.rs
@@ -1,0 +1,929 @@
+//! Reversible Trash quarantine for transcription recordings.
+//!
+//! Moves audio to `~/.thoth/Trash/` and snapshots the transcription row so
+//! it can be restored later.  `purge_trash` is the only permanent deletion
+//! path; all user-initiated deletes should route through `quarantine_recordings`.
+//!
+//! # Reference-count guard
+//!
+//! The WAV file is moved to the Trash dir **only when no other live
+//! `transcriptions` row still references the same `audio_path`**.  This mirrors
+//! the guard in `delete_transcription_with_conn` (transcription.rs ~line 246).
+//! `audio_moved` records whether the file was physically relocated so
+//! `restore_recordings` knows whether to move it back.
+//!
+//! # Startup auto-purge
+//!
+//! `auto_purge_expired` is called from `initialise_database` after migrations.
+//! It removes trash entries (and their WAV files) older than
+//! `TRASH_RETENTION_DAYS`.
+
+use chrono::Utc;
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::{Deserialize, Serialize};
+
+use crate::database::{DatabaseError, open_connection};
+use crate::error::Error;
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/// Trash entries older than this are removed on startup.
+const TRASH_RETENTION_DAYS: i64 = 30;
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+/// A snapshot of a quarantined transcription in the `trash` table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrashEntry {
+    pub id: String,
+    /// First ~80 characters of the original transcription text.
+    pub text_preview: String,
+    pub created_at: String,
+    pub deleted_at: String,
+    pub duration_seconds: Option<f64>,
+    /// File size at the time of quarantine, in bytes.
+    pub file_bytes: u64,
+    /// `true` when the WAV was moved to the Trash dir; `false` when another
+    /// live row still referenced the same path and the move was skipped.
+    pub audio_moved: bool,
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+/// Path to `~/.thoth/Trash/` (or `$THOTH_DATA_DIR/Trash/` in tests).
+fn trash_dir() -> Result<std::path::PathBuf, DatabaseError> {
+    let base = super::get_thoth_directory()?;
+    let dir = base.join("Trash");
+    if !dir.exists() {
+        std::fs::create_dir_all(&dir)?;
+    }
+    Ok(dir)
+}
+
+/// Destination path for a moved WAV: `Trash/<id>__<original_filename>`.
+fn trash_dest(id: &str, original: &std::path::Path) -> Result<std::path::PathBuf, DatabaseError> {
+    let filename = original
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("audio.wav");
+    let dest_name = format!("{}___{}", id, filename);
+    Ok(trash_dir()?.join(dest_name))
+}
+
+// =============================================================================
+// Core operations (accept a connection — testable without touching the global DB)
+// =============================================================================
+
+/// Quarantine a batch of recordings by ID.
+///
+/// For each ID:
+/// 1. Snapshot the `transcriptions` row into `trash`.
+/// 2. Delete the row from `transcriptions`.
+/// 3. Move the WAV to `~/.thoth/Trash/` **only if** no other live row still
+///    references that path.
+/// 4. Record `audio_moved` so restore knows whether to move the file back.
+///
+/// All steps are wrapped in a single `IMMEDIATE` transaction per ID so the
+/// ref-count check is race-free.  Returns the number of IDs successfully
+/// quarantined.
+#[allow(clippy::type_complexity)]
+pub(crate) fn quarantine_recordings_with_conn(
+    conn: &mut Connection,
+    ids: &[String],
+) -> Result<u32, DatabaseError> {
+    let mut quarantined: u32 = 0;
+
+    for id in ids {
+        // IMMEDIATE locks the writer slot so the DELETE → ref-count → trash
+        // INSERT sequence is atomic.
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+
+        // Read the full row before deletion.
+        let row: Option<(
+            String,         // text
+            Option<String>, // raw_text
+            Option<f64>,    // duration_seconds
+            String,         // created_at
+            Option<String>, // audio_path
+            i32,            // is_enhanced
+            Option<String>, // enhancement_prompt
+            Option<String>, // transcription_model_name
+            Option<f64>,    // transcription_duration_seconds
+            Option<String>, // enhancement_model_name
+            Option<f64>,    // enhancement_duration_seconds
+        )> = {
+            let mut stmt = tx.prepare(
+                r#"SELECT text, raw_text, duration_seconds, created_at, audio_path,
+                          is_enhanced, enhancement_prompt,
+                          transcription_model_name, transcription_duration_seconds,
+                          enhancement_model_name, enhancement_duration_seconds
+                   FROM transcriptions WHERE id = ?1"#,
+            )?;
+            stmt.query_row(params![id], |r| {
+                Ok((
+                    r.get(0)?,
+                    r.get(1)?,
+                    r.get(2)?,
+                    r.get(3)?,
+                    r.get(4)?,
+                    r.get(5)?,
+                    r.get(6)?,
+                    r.get(7)?,
+                    r.get(8)?,
+                    r.get(9)?,
+                    r.get(10)?,
+                ))
+            })
+            .optional()
+            .map_err(DatabaseError::from)?
+        };
+
+        let (
+            text,
+            raw_text,
+            duration_seconds,
+            created_at,
+            audio_path,
+            is_enhanced,
+            enhancement_prompt,
+            transcription_model_name,
+            transcription_duration_seconds,
+            enhancement_model_name,
+            enhancement_duration_seconds,
+        ) = match row {
+            Some(r) => r,
+            None => {
+                tracing::warn!("quarantine_recordings: id {} not found, skipping", id);
+                continue;
+            }
+        };
+
+        // Delete the live row.
+        let rows_deleted = tx.execute("DELETE FROM transcriptions WHERE id = ?1", params![id])?;
+        if rows_deleted == 0 {
+            continue;
+        }
+
+        // After the delete, count remaining live references to this audio path
+        // (inside the same transaction — race-free).
+        let remaining_refs: i64 = if let Some(ref path) = audio_path {
+            tx.query_row(
+                "SELECT COUNT(*) FROM transcriptions WHERE audio_path = ?1",
+                params![path],
+                |row| row.get(0),
+            )?
+        } else {
+            0
+        };
+
+        let deleted_at = Utc::now().to_rfc3339();
+
+        // Decide, inside the transaction, whether the WAV will be relocated to
+        // the Trash dir: only when it has a path and no other live row still
+        // references it. When it will move, the trash row's `audio_path` records
+        // the *destination* (so restore and purge know where the file actually
+        // is); `original_path` always records where to put it back. Determining
+        // this in-transaction (rather than patching `audio_moved` afterwards via
+        // a second connection) keeps the row consistent if the process dies
+        // before the move; restore tolerates a move that never completed.
+        let will_move = remaining_refs == 0 && audio_path.is_some();
+        let trash_location: Option<String> = if will_move {
+            let original = std::path::PathBuf::from(audio_path.as_ref().unwrap());
+            Some(trash_dest(id, &original)?.to_string_lossy().into_owned())
+        } else {
+            audio_path.clone()
+        };
+
+        tx.execute(
+            r#"INSERT INTO trash (
+                   id, text, raw_text, duration_seconds, created_at, audio_path,
+                   is_enhanced, enhancement_prompt,
+                   transcription_model_name, transcription_duration_seconds,
+                   enhancement_model_name, enhancement_duration_seconds,
+                   original_path, deleted_at, audio_moved
+               ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)"#,
+            params![
+                id,
+                text,
+                raw_text,
+                duration_seconds,
+                created_at,
+                trash_location, // audio_path = trash destination when moving, else original
+                is_enhanced,
+                enhancement_prompt,
+                transcription_model_name,
+                transcription_duration_seconds,
+                enhancement_model_name,
+                enhancement_duration_seconds,
+                audio_path, // original_path = where restore puts the file back
+                deleted_at,
+                will_move as i32,
+            ],
+        )?;
+
+        tx.commit()?;
+
+        // Move the file after the commit. The DB already records the intended
+        // destination, so restore/purge stay correct even if this move fails or
+        // the process dies here (restore falls back to the original path).
+        if will_move {
+            // will_move implies both are Some.
+            let src = std::path::PathBuf::from(audio_path.as_ref().unwrap());
+            let dest = std::path::PathBuf::from(trash_location.as_ref().unwrap());
+            match std::fs::rename(&src, &dest) {
+                Ok(()) => {
+                    tracing::debug!("Quarantined audio {} -> {}", src.display(), dest.display())
+                }
+                Err(e) => tracing::warn!(
+                    "Failed to move audio {} to trash (restore will fall back to the original path): {}",
+                    src.display(),
+                    e
+                ),
+            }
+        }
+
+        quarantined += 1;
+    }
+
+    Ok(quarantined)
+}
+
+/// Restore a batch of trash entries back to `transcriptions`.
+///
+/// For each ID:
+/// 1. Re-insert the snapshotted row into `transcriptions`.
+/// 2. If `audio_moved = true`, move the WAV back to `original_path`.
+/// 3. Delete the trash entry.
+///
+/// Returns the count of successfully restored entries.
+#[allow(clippy::type_complexity)]
+pub(crate) fn restore_recordings_with_conn(
+    conn: &mut Connection,
+    ids: &[String],
+) -> Result<u32, DatabaseError> {
+    let mut restored: u32 = 0;
+
+    for id in ids {
+        // Read the trash snapshot.
+        let snap: Option<(
+            String,         // text
+            Option<String>, // raw_text
+            Option<f64>,    // duration_seconds
+            String,         // created_at
+            Option<String>, // audio_path (current location in Trash/)
+            i32,            // is_enhanced
+            Option<String>, // enhancement_prompt
+            Option<String>, // transcription_model_name
+            Option<f64>,    // transcription_duration_seconds
+            Option<String>, // enhancement_model_name
+            Option<f64>,    // enhancement_duration_seconds
+            Option<String>, // original_path
+            i32,            // audio_moved
+        )> = {
+            let mut stmt = conn.prepare(
+                r#"SELECT text, raw_text, duration_seconds, created_at, audio_path,
+                          is_enhanced, enhancement_prompt,
+                          transcription_model_name, transcription_duration_seconds,
+                          enhancement_model_name, enhancement_duration_seconds,
+                          original_path, audio_moved
+                   FROM trash WHERE id = ?1"#,
+            )?;
+            stmt.query_row(params![id], |r| {
+                Ok((
+                    r.get(0)?,
+                    r.get(1)?,
+                    r.get(2)?,
+                    r.get(3)?,
+                    r.get(4)?,
+                    r.get(5)?,
+                    r.get(6)?,
+                    r.get(7)?,
+                    r.get(8)?,
+                    r.get(9)?,
+                    r.get(10)?,
+                    r.get(11)?,
+                    r.get(12)?,
+                ))
+            })
+            .optional()
+            .map_err(DatabaseError::from)?
+        };
+
+        let (
+            text,
+            raw_text,
+            duration_seconds,
+            created_at,
+            audio_path_in_trash,
+            is_enhanced,
+            enhancement_prompt,
+            transcription_model_name,
+            transcription_duration_seconds,
+            enhancement_model_name,
+            enhancement_duration_seconds,
+            original_path,
+            audio_moved,
+        ) = match snap {
+            Some(s) => s,
+            None => {
+                tracing::warn!("restore_recordings: id {} not in trash, skipping", id);
+                continue;
+            }
+        };
+
+        // Move the file back to original_path before re-inserting the row, so
+        // the restored row immediately has a valid audio_path. Tolerate a move
+        // that never completed: if the file is already at original_path (or the
+        // trash copy is missing), skip the move and still reference the original.
+        let restored_audio_path: Option<String> = if audio_moved != 0 {
+            if let Some(orig) = original_path.as_deref() {
+                let dst = std::path::PathBuf::from(orig);
+                if !dst.exists() {
+                    if let Some(src) = audio_path_in_trash.as_deref().map(std::path::PathBuf::from)
+                    {
+                        if src.exists() {
+                            if let Some(parent) = dst.parent() {
+                                let _ = std::fs::create_dir_all(parent);
+                            }
+                            match std::fs::rename(&src, &dst) {
+                                Ok(()) => {
+                                    tracing::debug!("Restored audio -> {}", dst.display())
+                                }
+                                Err(e) => {
+                                    tracing::warn!("Failed to move audio back for {}: {}", id, e)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            // The restored row always references the original path.
+            original_path.clone()
+        } else {
+            // File was never moved; the recorded audio_path is the original.
+            audio_path_in_trash.clone()
+        };
+
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+
+        tx.execute(
+            r#"INSERT OR IGNORE INTO transcriptions (
+                   id, text, raw_text, duration_seconds, created_at, audio_path,
+                   is_enhanced, enhancement_prompt,
+                   transcription_model_name, transcription_duration_seconds,
+                   enhancement_model_name, enhancement_duration_seconds
+               ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)"#,
+            params![
+                id,
+                text,
+                raw_text,
+                duration_seconds,
+                created_at,
+                restored_audio_path,
+                is_enhanced,
+                enhancement_prompt,
+                transcription_model_name,
+                transcription_duration_seconds,
+                enhancement_model_name,
+                enhancement_duration_seconds,
+            ],
+        )?;
+
+        tx.execute("DELETE FROM trash WHERE id = ?1", params![id])?;
+        tx.commit()?;
+
+        tracing::debug!("Restored transcription {} from trash", id);
+        restored += 1;
+    }
+
+    Ok(restored)
+}
+
+/// Permanently delete trash entries.
+///
+/// `ids = Some(...)` purges only those entries; `ids = None` purges everything.
+/// Removes the WAV from `~/.thoth/Trash/` when `audio_moved = true`.
+///
+/// Returns the count of entries purged.
+pub(crate) fn purge_trash_with_conn(
+    conn: &mut Connection,
+    ids: Option<&[String]>,
+) -> Result<u32, DatabaseError> {
+    // Collect the rows to purge.
+    let to_purge: Vec<(String, Option<String>, bool)> = {
+        let sql = match ids {
+            Some(_) => "SELECT id, audio_path, audio_moved FROM trash WHERE id = ?1",
+            None => "SELECT id, audio_path, audio_moved FROM trash",
+        };
+
+        if let Some(id_list) = ids {
+            let mut out = Vec::new();
+            for id in id_list {
+                let mut stmt = conn.prepare(sql)?;
+                let rows: Vec<_> = stmt
+                    .query_map(params![id], |r| {
+                        Ok((
+                            r.get::<_, String>(0)?,
+                            r.get::<_, Option<String>>(1)?,
+                            r.get::<_, i32>(2)? != 0,
+                        ))
+                    })?
+                    .collect::<Result<Vec<_>, _>>()?;
+                out.extend(rows);
+            }
+            out
+        } else {
+            let mut stmt = conn.prepare(sql)?;
+            stmt.query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, Option<String>>(1)?,
+                    r.get::<_, i32>(2)? != 0,
+                ))
+            })?
+            .collect::<Result<Vec<_>, _>>()?
+        }
+    };
+
+    let mut purged: u32 = 0;
+
+    for (id, audio_path, audio_moved) in &to_purge {
+        // Remove the WAV from Trash/ when we physically moved it there.
+        if *audio_moved {
+            if let Some(path_str) = audio_path {
+                let path = std::path::PathBuf::from(path_str);
+                match std::fs::remove_file(&path) {
+                    Ok(()) => tracing::debug!("Purged audio: {}", path.display()),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        tracing::warn!("Audio already gone during purge: {}", path.display());
+                    }
+                    Err(e) => tracing::warn!("Failed to purge audio {}: {}", path.display(), e),
+                }
+            }
+        }
+
+        conn.execute("DELETE FROM trash WHERE id = ?1", params![id])?;
+        purged += 1;
+    }
+
+    Ok(purged)
+}
+
+/// List all entries in the trash table.
+pub(crate) fn list_trash_with_conn(conn: &Connection) -> Result<Vec<TrashEntry>, DatabaseError> {
+    let mut stmt = conn.prepare(
+        r#"SELECT id,
+                  SUBSTR(COALESCE(text, ''), 1, 80) AS text_preview,
+                  created_at,
+                  deleted_at,
+                  duration_seconds,
+                  COALESCE(audio_path, '') AS audio_path_str,
+                  audio_moved
+           FROM trash
+           ORDER BY deleted_at DESC"#,
+    )?;
+
+    let rows = stmt
+        .query_map([], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, String>(2)?,
+                r.get::<_, String>(3)?,
+                r.get::<_, Option<f64>>(4)?,
+                r.get::<_, String>(5)?,
+                r.get::<_, i32>(6)?,
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let entries = rows
+        .into_iter()
+        .map(
+            |(
+                id,
+                text_preview,
+                created_at,
+                deleted_at,
+                duration_seconds,
+                audio_path_str,
+                audio_moved,
+            )| {
+                let file_bytes = if !audio_path_str.is_empty() {
+                    std::fs::metadata(&audio_path_str)
+                        .map(|m| m.len())
+                        .unwrap_or(0)
+                } else {
+                    0
+                };
+                TrashEntry {
+                    id,
+                    text_preview,
+                    created_at,
+                    deleted_at,
+                    duration_seconds,
+                    file_bytes,
+                    audio_moved: audio_moved != 0,
+                }
+            },
+        )
+        .collect();
+
+    Ok(entries)
+}
+
+/// Remove trash entries whose `deleted_at` is older than `TRASH_RETENTION_DAYS`.
+///
+/// Called from `initialise_database` after migrations.
+pub fn auto_purge_expired(conn: &mut Connection) -> Result<u32, DatabaseError> {
+    let cutoff = (Utc::now() - chrono::Duration::days(TRASH_RETENTION_DAYS)).to_rfc3339();
+
+    // Collect expired rows before deleting so we can remove WAVs.
+    let expired: Vec<(String, Option<String>, bool)> = {
+        let mut stmt =
+            conn.prepare("SELECT id, audio_path, audio_moved FROM trash WHERE deleted_at < ?1")?;
+        stmt.query_map(params![cutoff], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, Option<String>>(1)?,
+                r.get::<_, i32>(2)? != 0,
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()?
+    };
+
+    if expired.is_empty() {
+        return Ok(0);
+    }
+
+    let ids: Vec<String> = expired.iter().map(|(id, _, _)| id.clone()).collect();
+    let purged = purge_trash_with_conn(conn, Some(&ids))?;
+
+    if purged > 0 {
+        tracing::info!(
+            "Auto-purged {} trash entries older than {} days",
+            purged,
+            TRASH_RETENTION_DAYS
+        );
+    }
+
+    Ok(purged)
+}
+
+// =============================================================================
+// Tauri commands
+// =============================================================================
+
+/// Move recordings to the reversible trash.
+///
+/// Returns the count of recordings successfully quarantined.
+#[tauri::command]
+pub fn quarantine_recordings(ids: Vec<String>) -> Result<u32, Error> {
+    let mut conn = open_connection()?;
+    quarantine_recordings_with_conn(&mut conn, &ids).map_err(|e| {
+        tracing::error!("quarantine_recordings failed: {}", e);
+        Error::Database(e)
+    })
+}
+
+/// Restore quarantined recordings back to the live history.
+///
+/// Returns the count of recordings successfully restored.
+#[tauri::command]
+pub fn restore_recordings(ids: Vec<String>) -> Result<u32, Error> {
+    let mut conn = open_connection()?;
+    restore_recordings_with_conn(&mut conn, &ids).map_err(|e| {
+        tracing::error!("restore_recordings failed: {}", e);
+        Error::Database(e)
+    })
+}
+
+/// Permanently delete trash entries.
+///
+/// `ids = None` purges the entire trash.  Returns the count purged.
+#[tauri::command]
+pub fn purge_trash(ids: Option<Vec<String>>) -> Result<u32, Error> {
+    let mut conn = open_connection()?;
+    let id_slice = ids.as_deref();
+    purge_trash_with_conn(&mut conn, id_slice).map_err(|e| {
+        tracing::error!("purge_trash failed: {}", e);
+        Error::Database(e)
+    })
+}
+
+/// List all entries currently in the trash.
+#[tauri::command]
+pub fn list_trash() -> Result<Vec<TrashEntry>, Error> {
+    let conn = open_connection()?;
+    list_trash_with_conn(&conn).map_err(|e| {
+        tracing::error!("list_trash failed: {}", e);
+        Error::Database(e)
+    })
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::migrations::run_migrations;
+    use hound::{SampleFormat, WavSpec, WavWriter};
+    use rusqlite::Connection;
+
+    fn make_test_db() -> Connection {
+        let mut conn = Connection::open_in_memory().expect("in-memory DB");
+        conn.execute_batch("PRAGMA foreign_keys = ON;")
+            .expect("pragmas");
+        run_migrations(&mut conn).expect("migrations");
+        conn
+    }
+
+    /// Write a minimal 16-bit mono WAV to `path` so file-move assertions work.
+    fn write_dummy_wav(path: &std::path::Path) {
+        let spec = WavSpec {
+            channels: 1,
+            sample_rate: 16000,
+            bits_per_sample: 16,
+            sample_format: SampleFormat::Int,
+        };
+        let mut w = WavWriter::create(path, spec).expect("create wav");
+        for _ in 0..160 {
+            w.write_sample(1000i16).expect("write sample");
+        }
+        w.finalize().expect("finalize wav");
+    }
+
+    /// Seed a row into the `transcriptions` table, optionally with a WAV at `audio_path`.
+    fn seed_transcription(
+        conn: &Connection,
+        id: &str,
+        text: &str,
+        audio_path: Option<&str>,
+        duration: Option<f64>,
+    ) {
+        conn.execute(
+            r#"INSERT INTO transcriptions
+               (id, text, raw_text, duration_seconds, created_at, audio_path, is_enhanced)
+               VALUES (?1, ?2, NULL, ?3, '2024-01-01T00:00:00Z', ?4, 0)"#,
+            params![id, text, duration, audio_path],
+        )
+        .expect("seed transcription");
+    }
+
+    // -------------------------------------------------------------------------
+    // Quarantine → restore round-trip
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn quarantine_and_restore_round_trip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // SAFETY: tests run single-threaded (cargo test default); env mutation is
+        // confined to the test binary and cleaned up before the test returns.
+        unsafe { std::env::set_var("THOTH_DATA_DIR", dir.path()) };
+
+        let wav_path = dir.path().join("Recordings").join("test.wav");
+        std::fs::create_dir_all(wav_path.parent().unwrap()).unwrap();
+        write_dummy_wav(&wav_path);
+
+        let mut conn = make_test_db();
+        let wav_str = wav_path.to_str().unwrap();
+        seed_transcription(&conn, "t1", "hello world", Some(wav_str), Some(5.0));
+
+        // Quarantine.
+        let count =
+            quarantine_recordings_with_conn(&mut conn, &["t1".to_string()]).expect("quarantine");
+        assert_eq!(count, 1);
+
+        // Row must be gone from transcriptions.
+        let live: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM transcriptions WHERE id = 't1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(live, 0, "row must be removed from transcriptions");
+
+        // Row must be in trash.
+        let in_trash: i64 = conn
+            .query_row("SELECT COUNT(*) FROM trash WHERE id = 't1'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(in_trash, 1, "row must be in trash");
+
+        // Original WAV must no longer exist at source.
+        assert!(
+            !wav_path.exists(),
+            "WAV must have been moved out of Recordings/"
+        );
+
+        // audio_moved flag must be set.
+        let audio_moved: i32 = conn
+            .query_row("SELECT audio_moved FROM trash WHERE id = 't1'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(audio_moved, 1, "audio_moved must be 1");
+
+        // Restore.
+        let restored =
+            restore_recordings_with_conn(&mut conn, &["t1".to_string()]).expect("restore");
+        assert_eq!(restored, 1);
+
+        // Row must be back in transcriptions.
+        let back: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM transcriptions WHERE id = 't1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(back, 1, "row must be back in transcriptions after restore");
+
+        // Trash must be empty.
+        let still_in_trash: i64 = conn
+            .query_row("SELECT COUNT(*) FROM trash", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(still_in_trash, 0, "trash must be empty after restore");
+
+        // WAV must be back at original path.
+        assert!(wav_path.exists(), "WAV must be restored to original path");
+
+        // Clean up env var so other tests in the same run are unaffected.
+        unsafe { std::env::remove_var("THOTH_DATA_DIR") };
+    }
+
+    // -------------------------------------------------------------------------
+    // Shared audio path: file NOT moved, other row intact
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn quarantine_shared_audio_does_not_move_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // SAFETY: tests run single-threaded (cargo test default); env mutation is
+        // confined to the test binary and cleaned up before the test returns.
+        unsafe { std::env::set_var("THOTH_DATA_DIR", dir.path()) };
+
+        let wav_path = dir.path().join("Recordings").join("shared.wav");
+        std::fs::create_dir_all(wav_path.parent().unwrap()).unwrap();
+        write_dummy_wav(&wav_path);
+
+        let mut conn = make_test_db();
+        let wav_str = wav_path.to_str().unwrap();
+
+        // Two rows referencing the same audio file.
+        seed_transcription(&conn, "a", "text a", Some(wav_str), Some(3.0));
+        seed_transcription(&conn, "b", "text b", Some(wav_str), Some(3.0));
+
+        // Quarantine only "a".
+        let count =
+            quarantine_recordings_with_conn(&mut conn, &["a".to_string()]).expect("quarantine");
+        assert_eq!(count, 1);
+
+        // WAV must still exist (row "b" still references it).
+        assert!(
+            wav_path.exists(),
+            "WAV must NOT be moved while another row references it"
+        );
+
+        // audio_moved must be false.
+        let audio_moved: i32 = conn
+            .query_row("SELECT audio_moved FROM trash WHERE id = 'a'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(audio_moved, 0, "audio_moved must be 0 for shared audio");
+
+        // Row "b" must be untouched.
+        let b_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM transcriptions WHERE id = 'b'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(b_count, 1, "row 'b' must still be in transcriptions");
+
+        unsafe { std::env::remove_var("THOTH_DATA_DIR") };
+    }
+
+    // -------------------------------------------------------------------------
+    // Purge: removes WAV and row
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn purge_removes_wav_and_row() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // SAFETY: tests run single-threaded (cargo test default); env mutation is
+        // confined to the test binary and cleaned up before the test returns.
+        unsafe { std::env::set_var("THOTH_DATA_DIR", dir.path()) };
+
+        let wav_path = dir.path().join("Recordings").join("purge.wav");
+        std::fs::create_dir_all(wav_path.parent().unwrap()).unwrap();
+        write_dummy_wav(&wav_path);
+
+        let mut conn = make_test_db();
+        let wav_str = wav_path.to_str().unwrap();
+        seed_transcription(&conn, "p1", "purge me", Some(wav_str), Some(2.0));
+
+        // Quarantine.
+        quarantine_recordings_with_conn(&mut conn, &["p1".to_string()]).expect("quarantine");
+
+        // The WAV moved to Trash/.
+        assert!(!wav_path.exists(), "WAV moved to Trash");
+
+        // Determine the trash WAV path.
+        let trash_audio: String = conn
+            .query_row("SELECT audio_path FROM trash WHERE id = 'p1'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        let trash_wav = std::path::PathBuf::from(&trash_audio);
+        assert!(trash_wav.exists(), "Trash WAV must exist before purge");
+
+        // Purge.
+        let purged = purge_trash_with_conn(&mut conn, Some(&["p1".to_string()])).expect("purge");
+        assert_eq!(purged, 1);
+
+        // Trash WAV must be gone.
+        assert!(!trash_wav.exists(), "Trash WAV must be removed after purge");
+
+        // Trash row must be gone.
+        let in_trash: i64 = conn
+            .query_row("SELECT COUNT(*) FROM trash WHERE id = 'p1'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(in_trash, 0, "trash row must be gone after purge");
+
+        unsafe { std::env::remove_var("THOTH_DATA_DIR") };
+    }
+
+    // -------------------------------------------------------------------------
+    // Auto-purge respects the retention cutoff
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn auto_purge_respects_retention_cutoff() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // SAFETY: tests run single-threaded (cargo test default); env mutation is
+        // confined to the test binary and cleaned up before the test returns.
+        unsafe { std::env::set_var("THOTH_DATA_DIR", dir.path()) };
+
+        let mut conn = make_test_db();
+
+        // Insert an old trash entry directly (no audio, simpler).
+        let old_deleted_at =
+            (Utc::now() - chrono::Duration::days(TRASH_RETENTION_DAYS + 1)).to_rfc3339();
+        let recent_deleted_at = Utc::now().to_rfc3339();
+
+        conn.execute(
+            r#"INSERT INTO trash (id, text, raw_text, duration_seconds, created_at,
+                                  audio_path, is_enhanced, enhancement_prompt,
+                                  transcription_model_name, transcription_duration_seconds,
+                                  enhancement_model_name, enhancement_duration_seconds,
+                                  original_path, deleted_at, audio_moved)
+               VALUES ('old', 'old text', NULL, NULL, '2023-01-01T00:00:00Z',
+                       NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, ?1, 0)"#,
+            params![old_deleted_at],
+        )
+        .expect("insert old trash");
+
+        conn.execute(
+            r#"INSERT INTO trash (id, text, raw_text, duration_seconds, created_at,
+                                  audio_path, is_enhanced, enhancement_prompt,
+                                  transcription_model_name, transcription_duration_seconds,
+                                  enhancement_model_name, enhancement_duration_seconds,
+                                  original_path, deleted_at, audio_moved)
+               VALUES ('recent', 'recent text', NULL, NULL, '2024-01-01T00:00:00Z',
+                       NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, ?1, 0)"#,
+            params![recent_deleted_at],
+        )
+        .expect("insert recent trash");
+
+        let purged = auto_purge_expired(&mut conn).expect("auto_purge");
+        assert_eq!(purged, 1, "only the old entry should be purged");
+
+        let remaining: i64 = conn
+            .query_row("SELECT COUNT(*) FROM trash", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(remaining, 1, "recent entry must survive auto-purge");
+
+        let surviving_id: String = conn
+            .query_row("SELECT id FROM trash", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(surviving_id, "recent", "the recent entry must survive");
+
+        unsafe { std::env::remove_var("THOTH_DATA_DIR") };
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ pub mod recording_indicator;
 pub mod shortcuts;
 pub mod sound;
 pub mod storage;
+pub mod telemetry;
 pub mod text_insert;
 #[cfg(target_os = "macos")]
 mod traffic_lights;
@@ -158,14 +159,76 @@ pub(crate) fn ensure_crypto_provider() {
     });
 }
 
-#[cfg_attr(mobile, tauri::mobile_entry_point)]
-pub fn run() {
-    ensure_crypto_provider();
+/// Bridge between `init_logging` and the Tauri `setup` hook.
+///
+/// `init_logging` registers the Loki layer with the subscriber and stores the
+/// `BackgroundTask` here. The Tauri `setup` hook takes it out and spawns it on
+/// the async runtime once that runtime is available.
+static LOKI_TASK_STORE: std::sync::Mutex<Option<tracing_loki::BackgroundTask>> =
+    std::sync::Mutex::new(None);
 
-    // Set up file-based logging for debugging (local time for readability)
+/// Build a `tracing-loki` `(Layer, BackgroundTask)` pair from `LoggingConfig`.
+///
+/// Returns `None` on any error (bad URL, bad label name, etc.) so the caller
+/// gracefully falls back to local-only logging.
+fn build_loki_components(
+    cfg: &config::LoggingConfig,
+) -> Option<(tracing_loki::Layer, tracing_loki::BackgroundTask)> {
+    let url = cfg.loki_url.parse::<url::Url>().ok()?;
+
+    // hostname crate gives us the machine name without pulling in system deps beyond
+    // what is already in the tree.
+    let host = hostname::get()
+        .ok()
+        .map(|h| h.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let mut builder = tracing_loki::builder()
+        .label("app", "thoth")
+        .ok()?
+        .label("host", host)
+        .ok()?
+        .label("version", env!("CARGO_PKG_VERSION"))
+        .ok()?;
+
+    for pair in &cfg.loki_labels {
+        builder = builder.label(pair[0].as_str(), pair[1].as_str()).ok()?;
+    }
+
+    // Authorization header — value is intentionally not logged anywhere.
+    if !cfg.loki_auth.0.is_empty() {
+        builder = builder
+            .http_header("Authorization", cfg.loki_auth.0.as_str())
+            .ok()?;
+    }
+
+    if let Some(tenant) = &cfg.loki_tenant {
+        builder = builder.http_header("X-Scope-OrgID", tenant.as_str()).ok()?;
+    }
+
+    builder.build_url(url).ok()
+}
+
+/// Initialise the layered tracing subscriber.
+///
+/// Layers:
+/// - **File**: daily rolling appender (`~/.thoth/logs/thoth-YYYY-MM-DD.log`), retaining
+///   `local_retention_days` files before pruning the oldest.
+/// - **Stdout**: unchanged dev convenience.
+/// - **Loki (optional)**: built only when `logging.remote_enabled` is true and a URL is set.
+///   Filtered to `target == "telemetry"` events only — the structural privacy boundary that
+///   prevents transcript content from ever reaching the remote endpoint.
+///   The Loki `BackgroundTask` is stored in `LOKI_COMPONENTS` and spawned in the Tauri `setup`
+///   hook once the async runtime is available. The `Layer` itself is registered here so events
+///   queue into its channel from first use; the task just needs to start before the first flush.
+///
+/// Configuration is read synchronously from disk so the subscriber is ready before any event
+/// fires. Changes require a restart (documented in the UI).
+fn init_logging() {
+    use tracing_subscriber::Layer;
     use tracing_subscriber::prelude::*;
 
-    /// Format timestamps using the system's local time via chrono
+    /// Local-time timestamp formatter using chrono
     struct LocalTimer;
     impl tracing_subscriber::fmt::time::FormatTime for LocalTimer {
         fn format_time(
@@ -180,33 +243,80 @@ pub fn run() {
         }
     }
 
+    let logging_cfg = config::read_logging_config_early();
+
     let log_dir = dirs::home_dir()
         .map(|h| h.join(".thoth").join("logs"))
         .unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
     let _ = std::fs::create_dir_all(&log_dir);
-    let log_file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(log_dir.join("thoth-debug.log"))
-        .ok();
 
-    if let Some(file) = log_file {
-        let file_layer = tracing_subscriber::fmt::layer()
-            .with_writer(std::sync::Mutex::new(file))
-            .with_timer(LocalTimer)
-            .with_ansi(false);
-        let stdout_layer = tracing_subscriber::fmt::layer().with_timer(LocalTimer);
-        tracing_subscriber::registry()
-            .with(
-                tracing_subscriber::EnvFilter::try_from_default_env()
-                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-            )
-            .with(stdout_layer)
-            .with(file_layer)
-            .init();
-    } else {
-        tracing_subscriber::fmt().with_timer(LocalTimer).init();
+    // Daily rolling appender with bounded retention. Falls back to a no-op writer on
+    // error (e.g. permission denied) so the app still starts without logging to disk.
+    let (appender, guard) = match tracing_appender::rolling::Builder::new()
+        .rotation(tracing_appender::rolling::Rotation::DAILY)
+        .filename_prefix("thoth")
+        .filename_suffix("log")
+        .max_log_files(logging_cfg.local_retention_days as usize)
+        .build(&log_dir)
+    {
+        Ok(a) => tracing_appender::non_blocking(a),
+        Err(_) => tracing_appender::non_blocking(std::io::sink()),
+    };
+    // Leak the WorkerGuard so the background writer lives for the process lifetime
+    // and flushes on shutdown.
+    std::mem::forget(guard);
+
+    let file_layer = tracing_subscriber::fmt::layer()
+        .with_writer(appender)
+        .with_timer(LocalTimer)
+        .with_ansi(false);
+
+    let stdout_layer = tracing_subscriber::fmt::layer().with_timer(LocalTimer);
+
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+
+    let registry = tracing_subscriber::registry()
+        .with(env_filter)
+        .with(stdout_layer)
+        .with(file_layer);
+
+    if logging_cfg.remote_enabled && !logging_cfg.loki_url.is_empty() {
+        if let Some((loki_layer, loki_task)) = build_loki_components(&logging_cfg) {
+            // The Loki layer is filtered to `target == "telemetry"` only — the
+            // allow-list boundary that makes content leakage structurally impossible.
+            let telemetry_filter =
+                tracing_subscriber::filter::filter_fn(|meta| meta.target() == "telemetry");
+
+            // Store only the background task; the layer is consumed by registry.with().
+            // The Tauri setup hook takes the task out of LOKI_TASK_STORE and spawns it.
+            {
+                let mut stored = LOKI_TASK_STORE.lock().unwrap_or_else(|e| e.into_inner());
+                *stored = Some(loki_task);
+            }
+
+            registry
+                .with(loki_layer.with_filter(telemetry_filter))
+                .init();
+            return;
+        }
+        // Log after init so the warning reaches the file layer — call init first.
+        registry.init();
+        tracing::warn!(
+            "Loki remote logging enabled but layer could not be built (bad URL or label?); \
+             falling back to local-only logging"
+        );
+        return;
     }
+
+    registry.init();
+}
+
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+    ensure_crypto_provider();
+
+    init_logging();
 
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
@@ -235,6 +345,31 @@ pub fn run() {
     builder
         .setup(|app| {
             tracing::info!("Thoth starting");
+
+            // Spawn the Loki background task if the remote logging layer was built.
+            // init_logging() registered the layer and stored the task here; the async
+            // runtime is now live so we can spawn it. Events queued before this point
+            // are buffered in the layer's channel and drained once the task starts.
+            if let Some(task) = LOKI_TASK_STORE
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .take()
+            {
+                tauri::async_runtime::spawn(task);
+                tracing::info!("Loki telemetry background task started");
+
+                // Emit app-start telemetry event now that the task is live.
+                let gpu_label = platform::get_gpu_info()
+                    .map(|g| g.gpu_name.unwrap_or_else(|| g.compiled_backend.clone()))
+                    .unwrap_or_else(|_| "unknown".to_string());
+                tracing::info!(
+                    target: "telemetry",
+                    version = env!("CARGO_PKG_VERSION"),
+                    os = std::env::consts::OS,
+                    gpu = %gpu_label,
+                    "app_start"
+                );
+            }
 
             // Store the app handle for the few deep paths that emit user-facing
             // events without a handle of their own (e.g. audio device fallback).
@@ -609,6 +744,8 @@ pub fn run() {
             control_api::get_api_token,
             control_api::rotate_api_token,
             control_api::set_api_port,
+            // Logging / telemetry
+            telemetry::test_loki_connection,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -503,6 +503,11 @@ pub fn run() {
             database::insights::get_insights,
             database::insights::get_cruft_candidates,
             database::insights::compute_audio_rms,
+            // Trash / quarantine
+            database::trash::quarantine_recordings,
+            database::trash::restore_recordings,
+            database::trash::purge_trash,
+            database::trash::list_trash,
             // Export
             export::search_history,
             export::export_to_json,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -174,25 +174,51 @@ static LOKI_TASK_STORE: std::sync::Mutex<Option<tracing_loki::BackgroundTask>> =
 fn build_loki_components(
     cfg: &config::LoggingConfig,
 ) -> Option<(tracing_loki::Layer, tracing_loki::BackgroundTask)> {
+    use sha2::Digest;
+
     let url = cfg.loki_url.parse::<url::Url>().ok()?;
 
-    // hostname crate gives us the machine name without pulling in system deps beyond
-    // what is already in the tree.
-    let host = hostname::get()
-        .ok()
-        .map(|h| h.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "unknown".to_string());
+    // Derive a stable, non-identifying device id from the hostname via SHA-256.
+    // The raw hostname on macOS often embeds the operator's name (e.g.
+    // "Pauls-MacBook-Pro.local"); we never send that to Loki.
+    let host_id = {
+        let raw = hostname::get()
+            .ok()
+            .map(|h| h.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "unknown".to_string());
+        let digest = sha2::Sha256::digest(raw.as_bytes());
+        // 12 hex chars (48 bits) is enough for collision resistance across a
+        // household fleet and is short enough to be readable in Loki queries.
+        // GenericArray doesn't impl LowerHex, so encode byte-by-byte.
+        let hex: String = digest.iter().map(|b| format!("{:02x}", b)).collect();
+        hex[..12].to_string()
+    };
 
     let mut builder = tracing_loki::builder()
         .label("app", "thoth")
         .ok()?
-        .label("host", host)
+        .label("host", host_id)
         .ok()?
         .label("version", env!("CARGO_PKG_VERSION"))
         .ok()?;
 
     for pair in &cfg.loki_labels {
-        builder = builder.label(pair[0].as_str(), pair[1].as_str()).ok()?;
+        // Clone before the call: `.label()` consumes the builder regardless of
+        // whether it succeeds, so we keep a fallback to restore on error.
+        let prev = builder.clone();
+        match builder.label(pair[0].as_str(), pair[1].as_str()) {
+            Ok(b) => builder = b,
+            Err(e) => {
+                tracing::warn!(
+                    "Loki label rejected (key={:?}, value={:?}): {}; skipping this label",
+                    pair[0],
+                    pair[1],
+                    e
+                );
+                // Restore the pre-call builder so the remaining labels still apply.
+                builder = prev;
+            }
+        }
     }
 
     // Authorization header — bare token gets a Bearer prefix. Never logged.
@@ -273,8 +299,22 @@ fn init_logging() {
 
     let stdout_layer = tracing_subscriber::fmt::layer().with_timer(LocalTimer);
 
-    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    // When remote logging is enabled, guarantee that the "telemetry" target is
+    // always allowed through the global filter regardless of RUST_LOG directives.
+    // A crate-scoped directive like `thoth=debug` does NOT match the bare
+    // "telemetry" target and would silently drop Loki events. We append
+    // `,telemetry=info` so the telemetry target is always at least INFO-visible.
+    // When RUST_LOG is unset we fall back to "info" as before, so this only
+    // matters when the user sets RUST_LOG explicitly.
+    let env_filter = if logging_cfg.remote_enabled && !logging_cfg.loki_url.is_empty() {
+        let base = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
+        let directive = format!("{},telemetry=info", base);
+        tracing_subscriber::EnvFilter::try_new(&directive)
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,telemetry=info"))
+    } else {
+        tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"))
+    };
 
     let registry = tracing_subscriber::registry()
         .with(env_filter)
@@ -285,8 +325,15 @@ fn init_logging() {
         if let Some((loki_layer, loki_task)) = build_loki_components(&logging_cfg) {
             // The Loki layer is filtered to `target == "telemetry"` only — the
             // allow-list boundary that makes content leakage structurally impossible.
-            let telemetry_filter =
-                tracing_subscriber::filter::filter_fn(|meta| meta.target() == "telemetry");
+            // Additionally gate on the configured telemetry_level so the field
+            // actually controls Loki verbosity (default INFO on parse failure).
+            let level_filter: tracing_subscriber::filter::LevelFilter = logging_cfg
+                .telemetry_level
+                .parse()
+                .unwrap_or(tracing_subscriber::filter::LevelFilter::INFO);
+            let telemetry_filter = tracing_subscriber::filter::filter_fn(move |meta| {
+                telemetry::is_telemetry_event(meta) && *meta.level() <= level_filter
+            });
 
             // Store only the background task; the layer is consumed by registry.with().
             // The Tauri setup hook takes the task out of LOKI_TASK_STORE and spawns it.
@@ -637,7 +684,6 @@ pub fn run() {
             database::transcription::get_transcription_stats_cmd,
             database::insights::get_insights,
             database::insights::get_cruft_candidates,
-            database::insights::compute_audio_rms,
             // Trash / quarantine
             database::trash::quarantine_recordings,
             database::trash::restore_recordings,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -500,6 +500,9 @@ pub fn run() {
             database::transcription::search_transcriptions_text,
             database::transcription::count_transcriptions_filtered,
             database::transcription::get_transcription_stats_cmd,
+            database::insights::get_insights,
+            database::insights::get_cruft_candidates,
+            database::insights::compute_audio_rms,
             // Export
             export::search_history,
             export::export_to_json,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -195,10 +195,10 @@ fn build_loki_components(
         builder = builder.label(pair[0].as_str(), pair[1].as_str()).ok()?;
     }
 
-    // Authorization header — value is intentionally not logged anywhere.
-    if !cfg.loki_auth.0.is_empty() {
+    // Authorization header — bare token gets a Bearer prefix. Never logged.
+    if let Some(auth_val) = config::authorization_header(&cfg.loki_auth.0) {
         builder = builder
-            .http_header("Authorization", cfg.loki_auth.0.as_str())
+            .http_header("Authorization", auth_val.as_str())
             .ok()?;
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -746,6 +746,7 @@ pub fn run() {
             control_api::set_api_port,
             // Logging / telemetry
             telemetry::test_loki_connection,
+            config::set_loki_auth,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/mcp_server/mod.rs
+++ b/src-tauri/src/mcp_server/mod.rs
@@ -304,14 +304,29 @@ impl ThothMcp {
                 let patch = p
                     .patch
                     .ok_or_else(|| core_err("`patch` required for update".into()))?;
-                // Merge the patch onto the current config, then set.
+                // Canonicalise camelCase keys to snake_case before merging so that
+                // `{"localRetentionDays": 14}` and `{"local_retention_days": 14}` both
+                // work. Without this step, a camelCase key is added alongside the
+                // existing snake_case key and serde errors on "duplicate field".
+                let patch_val: serde_json::Value = serde_json::from_str(&patch)
+                    .map_err(|e| core_err(format!("invalid patch JSON: {}", e)))?;
+                if !patch_val.is_object() {
+                    return Err(core_err(
+                        "`patch` must be a JSON object, not a scalar or array".into(),
+                    ));
+                }
+                let patch_val = crate::config::canonicalise_patch_keys(patch_val);
+                // `get_config()` returns the config with loki_auth replaced by the mask
+                // sentinel "***". Merging onto this masked base is safe: if the patch does
+                // not include loki_auth, the sentinel survives into the merged Value and
+                // `set_config`'s mask/empty guard restores the real stored token. If the
+                // patch explicitly sends the sentinel, the same guard applies. The only way
+                // to clear loki_auth is via `set_loki_auth`.
                 let mut current = serde_json::to_value(
                     crate::config::get_config().map_err(|e| core_err(e.to_string()))?,
                 )
                 .map_err(|e| core_err(e.to_string()))?;
-                let patch_val: serde_json::Value = serde_json::from_str(&patch)
-                    .map_err(|e| core_err(format!("invalid patch JSON: {}", e)))?;
-                merge_json(&mut current, &patch_val);
+                crate::config::merge_json(&mut current, &patch_val);
                 let new_cfg: crate::config::Config = serde_json::from_value(current)
                     .map_err(|e| core_err(format!("merged config invalid: {}", e)))?;
                 crate::config::set_config(new_cfg).map_err(|e| core_err(e.to_string()))?;
@@ -434,16 +449,4 @@ pub fn build_service() -> StreamableHttpService<ThothMcp, LocalSessionManager> {
         LocalSessionManager::default().into(),
         StreamableHttpServerConfig::default(),
     )
-}
-
-/// Recursively merge `patch` into `target` (objects merged key-wise; other values replaced).
-fn merge_json(target: &mut serde_json::Value, patch: &serde_json::Value) {
-    match (target, patch) {
-        (serde_json::Value::Object(t), serde_json::Value::Object(p)) => {
-            for (k, v) in p {
-                merge_json(t.entry(k.clone()).or_insert(serde_json::Value::Null), v);
-            }
-        }
-        (t, p) => *t = p.clone(),
-    }
 }

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -550,24 +550,23 @@ async fn run_transcription_pipeline(
 
     // Content-free telemetry — no transcript text, only metrics.
     {
-        let audio_secs = audio_path
-            .parse::<f64>()
-            .ok()
-            .or_else(|| get_audio_duration(audio_path))
-            .unwrap_or(0.0);
-        let speed_factor = if transcription_duration_seconds > 0.0 {
-            audio_secs / transcription_duration_seconds
-        } else {
-            0.0
+        // audio_path is a WAV file path, not a number; parse::<f64>() always
+        // fails and was dead code. Use get_audio_duration directly.
+        let audio_secs = get_audio_duration(audio_path);
+        let speed_factor = match audio_secs {
+            Some(secs) if transcription_duration_seconds > 0.0 => {
+                secs / transcription_duration_seconds
+            }
+            _ => 0.0,
         };
         let model_label = transcription_model_name.as_deref().unwrap_or("unknown");
         tracing::info!(
             target: "telemetry",
             backend = %model_label,
-            audio_seconds = audio_secs,
+            audio_seconds = audio_secs.unwrap_or(0.0),
             processing_seconds = transcription_duration_seconds,
             speed_factor = speed_factor,
-            char_count = raw_text.len(),
+            char_count = raw_text.chars().count(),
             "transcription_complete"
         );
     }

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -193,6 +193,7 @@ fn discard_silent_wav(result: &Result<PipelineResult, String>, audio_path: &str)
         "Pipeline: Silent recording, deleting orphan WAV: {}",
         audio_path
     );
+    tracing::info!(target: "telemetry", event = "recording_silent_dropped", "recording_silent_dropped");
     if let Err(del_err) = std::fs::remove_file(audio_path) {
         tracing::warn!(
             "Pipeline: Failed to delete silent WAV {}: {}",
@@ -255,6 +256,7 @@ pub fn pipeline_start_recording(app: AppHandle) -> Result<String, Error> {
         if !transcription::download::check_model_downloaded(None) {
             PIPELINE_RUNNING.store(false, Ordering::SeqCst);
             tracing::warn!("Pipeline: No transcription model downloaded, blocking recording");
+            tracing::warn!(target: "telemetry", reason = "no_model_downloaded", "model_load_failure");
             let _ = crate::recording_indicator::hide_recording_indicator(app.clone());
             return Err(
                 "No transcription model downloaded. Open Settings \u{2192} Models to get started."
@@ -278,6 +280,7 @@ pub fn pipeline_start_recording(app: AppHandle) -> Result<String, Error> {
     match crate::audio::start_recording() {
         Ok(path) => {
             tracing::info!("Pipeline: Recording started at {}", path);
+            tracing::info!(target: "telemetry", event = "recording_started", "recording_started");
 
             // Now that start_recording has resolved (and stored) the device name,
             // emit a follow-up progress event that includes it for the UI.
@@ -309,6 +312,7 @@ pub fn pipeline_start_recording(app: AppHandle) -> Result<String, Error> {
         }
         Err(e) => {
             PIPELINE_RUNNING.store(false, Ordering::SeqCst);
+            tracing::warn!(target: "telemetry", reason = "audio_start_failed", "audio_device_failure");
             emit_progress(
                 &app,
                 PipelineState::Failed,
@@ -365,6 +369,14 @@ pub async fn pipeline_stop_and_process(
     // Capture has stopped — release PIPELINE_RUNNING so a new recording can start
     // immediately while this task processes.
     PIPELINE_RUNNING.store(false, Ordering::SeqCst);
+
+    // Recording duration from the WAV header; 0.0 if unavailable.
+    let rec_duration = get_audio_duration(&audio_path).unwrap_or(0.0);
+    tracing::info!(
+        target: "telemetry",
+        duration_seconds = rec_duration,
+        "recording_stopped"
+    );
 
     tracing::info!(
         "Pipeline: Recording stopped, spawning detached process task for {}",
@@ -506,6 +518,7 @@ async fn run_transcription_pipeline(
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
         while !transcription::is_transcription_ready() {
             if std::time::Instant::now() > deadline {
+                tracing::warn!(target: "telemetry", reason = "load_timeout_60s", "model_load_failure");
                 return Err("Transcription model failed to load within 60 seconds".to_string());
             }
             std::thread::sleep(std::time::Duration::from_millis(100));
@@ -533,6 +546,30 @@ async fn run_transcription_pipeline(
     if raw_text.trim().is_empty() {
         tracing::warn!("Pipeline: Transcription produced no text");
         return Err(NO_SPEECH_ERROR.to_string());
+    }
+
+    // Content-free telemetry — no transcript text, only metrics.
+    {
+        let audio_secs = audio_path
+            .parse::<f64>()
+            .ok()
+            .or_else(|| get_audio_duration(audio_path))
+            .unwrap_or(0.0);
+        let speed_factor = if transcription_duration_seconds > 0.0 {
+            audio_secs / transcription_duration_seconds
+        } else {
+            0.0
+        };
+        let model_label = transcription_model_name.as_deref().unwrap_or("unknown");
+        tracing::info!(
+            target: "telemetry",
+            backend = %model_label,
+            audio_seconds = audio_secs,
+            processing_seconds = transcription_duration_seconds,
+            speed_factor = speed_factor,
+            char_count = raw_text.len(),
+            "transcription_complete"
+        );
     }
 
     tracing::info!(
@@ -607,10 +644,26 @@ async fn run_transcription_pipeline(
                     text.len(),
                     elapsed
                 );
+                // Deliberately no prompt text/id: the telemetry stream is
+                // content-free, and enhancement-by-prompt analytics already
+                // live in the Insights dashboard (from the DB column).
+                tracing::info!(
+                    target: "telemetry",
+                    model = %config.enhancement_model,
+                    duration_seconds = elapsed,
+                    ok = true,
+                    "enhancement_complete"
+                );
                 true
             }
             Err(e) => {
                 tracing::warn!("Pipeline: Enhancement failed, using original text: {}", e);
+                tracing::warn!(
+                    target: "telemetry",
+                    model = %config.enhancement_model,
+                    ok = false,
+                    "enhancement_complete"
+                );
                 false
             }
         }

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -1,22 +1,47 @@
 //! Telemetry and observability export
 //!
 //! Provides the `test_loki_connection` Tauri command used by the Settings
-//! "Test connection" button, and re-exports helpers for structured telemetry
-//! event emission.
+//! "Test connection" button, and helpers for the Loki filter predicate.
 
 use crate::error::Error;
+
+/// The literal target string used for all Loki-bound telemetry events.
+///
+/// Both the subscriber filter in `init_logging` and the unit tests refer to
+/// this constant so a typo or rename fails compilation rather than silently
+/// opening a privacy hole.
+pub(crate) const TELEMETRY_TARGET: &str = "telemetry";
+
+/// Returns `true` when a tracing event targets the Loki-only "telemetry" channel.
+///
+/// This is the single source of truth for the allow-list predicate used in
+/// `init_logging`'s `filter_fn`. Extracting it here lets unit tests call the
+/// same function rather than duplicating the literal string comparison.
+pub(crate) fn is_telemetry_event(meta: &tracing::Metadata<'_>) -> bool {
+    meta.target() == TELEMETRY_TARGET
+}
+
+/// Target-string form of `is_telemetry_event` for use in unit tests that
+/// cannot easily construct a real `tracing::Metadata`.
+#[cfg(test)]
+pub(crate) fn is_telemetry_event_by_target(target: &str) -> bool {
+    target == TELEMETRY_TARGET
+}
 
 /// Push a single synthetic telemetry line to the given Loki endpoint.
 ///
 /// Used by the Settings "Test connection" button to verify that the URL,
 /// auth token, and tenant are correct before the user saves and restarts.
-/// Tests the VALUES currently on-screen rather than the saved config so the
-/// user can test before/independently of saving. Returns `Ok(())` if Loki
-/// accepted the push (2xx response), or an error string describing the failure.
+///
+/// `auth` is `Option<String>`: when the caller passes `None`, empty string, or
+/// the mask sentinel (`***`), the command resolves the effective token from the
+/// in-memory config (the real, unmasked value).  This handles the normal day-2
+/// case where the frontend shows `***` and the user just clicks "Test" without
+/// re-entering the token.
 #[tauri::command]
 pub async fn test_loki_connection(
     url: String,
-    auth: String,
+    auth: Option<String>,
     tenant: Option<String>,
 ) -> Result<(), Error> {
     crate::ensure_crypto_provider();
@@ -24,6 +49,26 @@ pub async fn test_loki_connection(
     if url.is_empty() {
         return Err("Loki URL is required".to_string().into());
     }
+
+    // Resolve the effective auth token: if the caller passed None, empty, or
+    // the mask sentinel, fall back to the real stored token. Read directly from
+    // the in-memory config instance rather than through get_config() (which
+    // masks the token and would just give us *** back again).
+    let effective_auth: String = {
+        let raw = auth.as_deref().unwrap_or("");
+        if raw.is_empty() || raw == crate::config::LOKI_AUTH_MASK {
+            // Read the unmasked token from the live in-memory config.
+            crate::config::get_raw_loki_auth()
+        } else {
+            raw.to_string()
+        }
+    };
+
+    // Resolve the effective tenant the same way.
+    let effective_tenant: Option<String> = match tenant.as_deref() {
+        Some(t) if !t.is_empty() => Some(t.to_string()),
+        _ => crate::config::get_raw_loki_tenant(),
+    };
 
     // Accept either a bare base URL ("http://loki:3100") or one that already
     // ends with the push path so callers don't have to strip it themselves.
@@ -49,20 +94,24 @@ pub async fn test_loki_connection(
         }]
     });
 
-    let mut req_builder = reqwest::Client::new()
+    // 10-second timeout so a slow or hostile Loki URL cannot hang the Settings page.
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("Failed to build HTTP client: {}", e))?;
+
+    let mut req_builder = client
         .post(&push_url)
         .header("Content-Type", "application/json")
         .body(body.to_string());
 
     // Normalise to a full Authorization header (bare token gets a Bearer
     // prefix). Empty/masked yields None — push unauthenticated. Never logged.
-    if let Some(auth_val) = crate::config::authorization_header(&auth) {
+    if let Some(auth_val) = crate::config::authorization_header(&effective_auth) {
         req_builder = req_builder.header("Authorization", auth_val);
     }
-    if let Some(ref t) = tenant {
-        if !t.is_empty() {
-            req_builder = req_builder.header("X-Scope-OrgID", t.as_str());
-        }
+    if let Some(ref t) = effective_tenant {
+        req_builder = req_builder.header("X-Scope-OrgID", t.as_str());
     }
 
     let response = req_builder
@@ -79,7 +128,44 @@ pub async fn test_loki_connection(
         Ok(())
     } else {
         let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        Err(format!("Loki returned {}: {}", status, body).into())
+        let body_text = response.text().await.unwrap_or_default();
+        // Truncate to 200 chars so a hostile server cannot embed a huge blob in
+        // the error string that gets rendered in the Settings UI. Collect by
+        // char so the slice is never on a multibyte UTF-8 boundary.
+        let truncated = {
+            let mut chars = body_text.chars();
+            let head: String = chars.by_ref().take(200).collect();
+            if chars.next().is_some() {
+                format!("{head}…")
+            } else {
+                head
+            }
+        };
+        Err(format!("Loki returned {}: {}", status, truncated).into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn telemetry_event_predicate_passes_telemetry_target() {
+        // Exercises the live predicate via its target-string form so a rename
+        // of TELEMETRY_TARGET would break this test.
+        assert!(
+            is_telemetry_event_by_target(TELEMETRY_TARGET),
+            "telemetry target must pass the filter"
+        );
+    }
+
+    #[test]
+    fn telemetry_event_predicate_blocks_other_targets() {
+        for target in &["thoth::pipeline", "thoth::audio", "tracing", "info"] {
+            assert!(
+                !is_telemetry_event_by_target(target),
+                "target '{target}' must be blocked by the telemetry filter"
+            );
+        }
     }
 }

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -6,27 +6,32 @@
 
 use crate::error::Error;
 
-/// Push a single synthetic telemetry line to the configured Loki endpoint.
+/// Push a single synthetic telemetry line to the given Loki endpoint.
 ///
 /// Used by the Settings "Test connection" button to verify that the URL,
 /// auth token, and tenant are correct before the user saves and restarts.
-/// Returns `Ok(())` if Loki accepted the push (2xx response), or an error
-/// string describing the failure.
+/// Tests the VALUES currently on-screen rather than the saved config so the
+/// user can test before/independently of saving. Returns `Ok(())` if Loki
+/// accepted the push (2xx response), or an error string describing the failure.
 #[tauri::command]
-pub async fn test_loki_connection() -> Result<(), Error> {
+pub async fn test_loki_connection(
+    url: String,
+    auth: String,
+    tenant: Option<String>,
+) -> Result<(), Error> {
     crate::ensure_crypto_provider();
 
-    let cfg = crate::config::get_config().map_err(|e| format!("Failed to read config: {}", e))?;
-    let loki_cfg = &cfg.logging;
-
-    if !loki_cfg.remote_enabled || loki_cfg.loki_url.is_empty() {
-        return Err("Loki remote logging is not configured".to_string().into());
+    if url.is_empty() {
+        return Err("Loki URL is required".to_string().into());
     }
 
-    let url = format!(
-        "{}/loki/api/v1/push",
-        loki_cfg.loki_url.trim_end_matches('/')
-    );
+    // Accept either a bare base URL ("http://loki:3100") or one that already
+    // ends with the push path so callers don't have to strip it themselves.
+    let push_url = if url.ends_with("/loki/api/v1/push") {
+        url.clone()
+    } else {
+        format!("{}/loki/api/v1/push", url.trim_end_matches('/'))
+    };
 
     let now_ns = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -45,22 +50,30 @@ pub async fn test_loki_connection() -> Result<(), Error> {
     });
 
     let mut req_builder = reqwest::Client::new()
-        .post(&url)
+        .post(&push_url)
         .header("Content-Type", "application/json")
         .body(body.to_string());
 
     // Authorization header value is used directly without logging.
-    if !loki_cfg.loki_auth.0.is_empty() {
-        req_builder = req_builder.header("Authorization", loki_cfg.loki_auth.0.as_str());
+    let effective_auth = if auth.is_empty() || auth == crate::config::LOKI_AUTH_MASK {
+        // Empty or mask sentinel: try without auth (Loki may allow unauthenticated push)
+        None
+    } else {
+        Some(auth)
+    };
+    if let Some(ref auth_val) = effective_auth {
+        req_builder = req_builder.header("Authorization", auth_val.as_str());
     }
-    if let Some(tenant) = &loki_cfg.loki_tenant {
-        req_builder = req_builder.header("X-Scope-OrgID", tenant.as_str());
+    if let Some(ref t) = tenant {
+        if !t.is_empty() {
+            req_builder = req_builder.header("X-Scope-OrgID", t.as_str());
+        }
     }
 
     let response = req_builder
         .send()
         .await
-        .map_err(|e| format!("Failed to reach Loki at {}: {}", url, e))?;
+        .map_err(|e| format!("Failed to reach Loki at {}: {}", push_url, e))?;
 
     if response.status().is_success() {
         tracing::info!(

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -1,0 +1,77 @@
+//! Telemetry and observability export
+//!
+//! Provides the `test_loki_connection` Tauri command used by the Settings
+//! "Test connection" button, and re-exports helpers for structured telemetry
+//! event emission.
+
+use crate::error::Error;
+
+/// Push a single synthetic telemetry line to the configured Loki endpoint.
+///
+/// Used by the Settings "Test connection" button to verify that the URL,
+/// auth token, and tenant are correct before the user saves and restarts.
+/// Returns `Ok(())` if Loki accepted the push (2xx response), or an error
+/// string describing the failure.
+#[tauri::command]
+pub async fn test_loki_connection() -> Result<(), Error> {
+    crate::ensure_crypto_provider();
+
+    let cfg = crate::config::get_config().map_err(|e| format!("Failed to read config: {}", e))?;
+    let loki_cfg = &cfg.logging;
+
+    if !loki_cfg.remote_enabled || loki_cfg.loki_url.is_empty() {
+        return Err("Loki remote logging is not configured".to_string().into());
+    }
+
+    let url = format!(
+        "{}/loki/api/v1/push",
+        loki_cfg.loki_url.trim_end_matches('/')
+    );
+
+    let now_ns = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+
+    // Minimal Loki JSON push payload — no transcript content, just a synthetic event.
+    let body = serde_json::json!({
+        "streams": [{
+            "stream": {
+                "app": "thoth",
+                "version": env!("CARGO_PKG_VERSION")
+            },
+            "values": [[now_ns.to_string(), "event=test_connection"]]
+        }]
+    });
+
+    let mut req_builder = reqwest::Client::new()
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .body(body.to_string());
+
+    // Authorization header value is used directly without logging.
+    if !loki_cfg.loki_auth.0.is_empty() {
+        req_builder = req_builder.header("Authorization", loki_cfg.loki_auth.0.as_str());
+    }
+    if let Some(tenant) = &loki_cfg.loki_tenant {
+        req_builder = req_builder.header("X-Scope-OrgID", tenant.as_str());
+    }
+
+    let response = req_builder
+        .send()
+        .await
+        .map_err(|e| format!("Failed to reach Loki at {}: {}", url, e))?;
+
+    if response.status().is_success() {
+        tracing::info!(
+            target: "telemetry",
+            event = "test_connection",
+            "loki_test_connection_ok"
+        );
+        Ok(())
+    } else {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        Err(format!("Loki returned {}: {}", status, body).into())
+    }
+}

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -54,15 +54,10 @@ pub async fn test_loki_connection(
         .header("Content-Type", "application/json")
         .body(body.to_string());
 
-    // Authorization header value is used directly without logging.
-    let effective_auth = if auth.is_empty() || auth == crate::config::LOKI_AUTH_MASK {
-        // Empty or mask sentinel: try without auth (Loki may allow unauthenticated push)
-        None
-    } else {
-        Some(auth)
-    };
-    if let Some(ref auth_val) = effective_auth {
-        req_builder = req_builder.header("Authorization", auth_val.as_str());
+    // Normalise to a full Authorization header (bare token gets a Bearer
+    // prefix). Empty/masked yields None — push unauthenticated. Never logged.
+    if let Some(auth_val) = crate::config::authorization_header(&auth) {
+        req_builder = req_builder.header("Authorization", auth_val);
     }
     if let Some(ref t) = tenant {
         if !t.is_empty() {

--- a/src-tauri/src/transcription/filter.rs
+++ b/src-tauri/src/transcription/filter.rs
@@ -69,6 +69,17 @@ static FILLER_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?i)\b(u+[hm]+|e+r+|a+h+)\b").unwrap()
 });
 
+/// Sentence-initial filler, with its spoken "pause" comma and the first letter
+/// of the word it was hiding. A dictated "Ah, so then..." transcribes the filler
+/// as the capitalised sentence start followed by a comma; deleting only the word
+/// would orphan that comma and leave the new first word lowercase (", so then").
+/// Group 1 is the sentence boundary (re-emitted); group 2 is the next word's
+/// first letter, which is upper-cased so the repaired sentence reads correctly
+/// regardless of the `sentence_case` option.
+static LEADING_FILLER_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)(\A|[.!?]\s+)(?:u+[hm]+|e+r+|a+h+)\b[ \t]*,?[ \t]*([A-Za-z])").unwrap()
+});
+
 /// Multiple whitespace pattern
 static MULTI_SPACE_PATTERN: LazyLock<Regex> = LazyLock::new(|| Regex::new(r" {2,}").unwrap());
 
@@ -89,6 +100,17 @@ static SPACE_BEFORE_PUNCT_PATTERN: LazyLock<Regex> =
 /// Missing space after punctuation pattern
 static MISSING_SPACE_AFTER_PUNCT_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"([.!?,;:])([A-Za-z])").unwrap());
+
+/// Orphaned punctuation left at the very start of the text — e.g. a pause comma
+/// stranded after a leading filler was removed ("Ah, 1995" → ", 1995").
+static LEADING_ORPHAN_PUNCT_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s*[,;:][\s,;:]*").unwrap());
+
+/// Repeated commas (with optional intervening whitespace) collapse to one — the
+/// artefact a mid-sentence filler leaves behind ("was, uh, thinking" → "was, ,
+/// thinking").
+static REPEATED_COMMA_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r",(?:\s*,)+").unwrap());
 
 /// Sentence start pattern (for capitalisation)
 static SENTENCE_START_PATTERN: LazyLock<Regex> =
@@ -168,9 +190,20 @@ impl OutputFilter {
     }
 }
 
-/// Remove common filler words and sounds from text
+/// Remove common filler words and sounds from text.
+///
+/// A sentence-initial filler is removed together with its spoken pause comma,
+/// and the word it was hiding is re-capitalised so "Ah, so then..." becomes
+/// "So then..." rather than a stranded ", so then...". Remaining mid-sentence
+/// fillers are simply deleted; the doubled commas and stray spaces they leave
+/// are tidied by [`cleanup_punctuation`] and [`normalise_whitespace`].
 pub fn remove_filler_words(text: &str) -> String {
-    FILLER_PATTERN.replace_all(text, "").to_string()
+    let repaired = LEADING_FILLER_PATTERN.replace_all(text, |caps: &regex::Captures| {
+        let boundary = caps.get(1).map_or("", |m| m.as_str());
+        let letter = caps.get(2).map_or("", |m| m.as_str());
+        format!("{}{}", boundary, letter.to_uppercase())
+    });
+    FILLER_PATTERN.replace_all(&repaired, "").to_string()
 }
 
 /// Normalise whitespace by collapsing multiple spaces and trimming
@@ -181,8 +214,14 @@ pub fn normalise_whitespace(text: &str) -> String {
 
 /// Clean up punctuation issues
 pub fn cleanup_punctuation(text: &str) -> String {
+    // Strip punctuation orphaned at the start of the text (e.g. a pause comma
+    // stranded after a leading filler was removed) and collapse the doubled
+    // commas a mid-sentence filler leaves behind.
+    let result = LEADING_ORPHAN_PUNCT_PATTERN.replace_all(text, "");
+    let result = REPEATED_COMMA_PATTERN.replace_all(&result, ",");
+
     // Remove duplicate punctuation (... -> ., !!! -> !, ??? -> ?)
-    let result = DUPLICATE_PERIOD_PATTERN.replace_all(text, ".");
+    let result = DUPLICATE_PERIOD_PATTERN.replace_all(&result, ".");
     let result = DUPLICATE_EXCLAIM_PATTERN.replace_all(&result, "!");
     let result = DUPLICATE_QUESTION_PATTERN.replace_all(&result, "?");
 
@@ -770,14 +809,15 @@ mod tests {
     #[test]
     fn test_remove_um() {
         assert_eq!(remove_filler_words("I um think so"), "I  think so");
-        assert_eq!(remove_filler_words("Um hello"), " hello");
+        // Sentence-initial filler: removed and the next word re-capitalised.
+        assert_eq!(remove_filler_words("Um hello"), "Hello");
         assert_eq!(remove_filler_words("hello um"), "hello ");
     }
 
     #[test]
     fn test_remove_uh() {
         assert_eq!(remove_filler_words("I uh need help"), "I  need help");
-        assert_eq!(remove_filler_words("Uh what"), " what");
+        assert_eq!(remove_filler_words("Uh what"), "What");
     }
 
     #[test]
@@ -788,8 +828,27 @@ mod tests {
 
     #[test]
     fn test_remove_ah() {
-        assert_eq!(remove_filler_words("Ah I see"), " I see");
+        assert_eq!(remove_filler_words("Ah I see"), "I see");
         assert_eq!(remove_filler_words("So ah yes"), "So  yes");
+    }
+
+    #[test]
+    fn test_remove_leading_filler_with_pause_comma() {
+        // The reported bug: a dictated "Ah, ..." transcribes as a capitalised
+        // filler plus a pause comma; removing only the word must not orphan the
+        // comma or leave the new first word lowercase.
+        assert_eq!(
+            remove_filler_words("Ah, so then, but it comes back to what I was saying."),
+            "So then, but it comes back to what I was saying."
+        );
+        assert_eq!(remove_filler_words("Um, then I left."), "Then I left.");
+        // Mid-text sentence start (after a terminator) is repaired too.
+        assert_eq!(
+            remove_filler_words("I went home. Um, then I left."),
+            "I went home. Then I left."
+        );
+        // Already-capitalised next word: filler and pause comma still removed.
+        assert_eq!(remove_filler_words("Ah, I see"), "I see");
     }
 
     #[test]
@@ -821,15 +880,17 @@ mod tests {
 
     #[test]
     fn test_remove_multiple_fillers() {
+        // Leading "Um," is repaired (comma dropped, "I" kept); the mid-sentence
+        // "uh" leaves a doubled comma that cleanup_punctuation later collapses.
         assert_eq!(
             remove_filler_words("Um, I was, uh, like thinking, you know"),
-            ", I was, , like thinking, you know"
+            "I was, , like thinking, you know"
         );
     }
 
     #[test]
     fn test_case_insensitive_fillers() {
-        assert_eq!(remove_filler_words("UM hello"), " hello");
+        assert_eq!(remove_filler_words("UM hello"), "Hello");
         assert_eq!(remove_filler_words("I UH think"), "I  think");
     }
 
@@ -897,6 +958,20 @@ mod tests {
         assert_eq!(cleanup_punctuation("What ??Really"), "What? Really");
     }
 
+    #[test]
+    fn test_strip_leading_orphan_punctuation() {
+        // A pause comma stranded at the start (filler removed before a word that
+        // was already capitalised, e.g. a name or "I").
+        assert_eq!(cleanup_punctuation(", I see"), "I see");
+        assert_eq!(cleanup_punctuation("  ; hello"), "hello");
+    }
+
+    #[test]
+    fn test_collapse_repeated_commas() {
+        assert_eq!(cleanup_punctuation("was, , thinking"), "was, thinking");
+        assert_eq!(cleanup_punctuation("a,,b"), "a, b");
+    }
+
     // Sentence case tests
 
     #[test]
@@ -950,9 +1025,10 @@ mod tests {
         let input = "um, I was like  thinking...what do you think ??";
         let result = filter.filter(input);
 
-        // "um" removed; "like" preserved (not a hesitation sound); spaces normalised;
-        // punctuation cleaned; sentence case applied
-        assert_eq!(result, ", I was like thinking. What do you think?");
+        // "um" and its pause comma removed (no orphaned leading comma); "like"
+        // preserved (not a hesitation sound); spaces normalised; punctuation
+        // cleaned; sentence case applied
+        assert_eq!(result, "I was like thinking. What do you think?");
     }
 
     #[test]
@@ -1165,6 +1241,34 @@ mod tests {
         assert_eq!(
             result,
             "So like I was thinking you know about the project. And I think we should like move forward with it what do you think?"
+        );
+    }
+
+    #[test]
+    fn test_leading_filler_repaired_without_sentence_case() {
+        // Reproduces the reported bug under the real defaults: the engine emits
+        // native casing, so sentence_case stays OFF. A leading "Ah," must still
+        // be repaired (comma dropped, "so" capitalised) rather than left as
+        // ", so then...".
+        let filter = OutputFilter::new(FilterOptions {
+            remove_fillers: true,
+            normalise_whitespace: true,
+            cleanup_punctuation: true,
+            sentence_case: false,
+            apply_dictionary: false,
+            australian_spelling: false,
+            spoken_numbers_to_digits: false,
+            voice_formatting_commands: true,
+        });
+
+        assert_eq!(
+            filter.filter("Ah, so then, but it comes back to what I was saying."),
+            "So then, but it comes back to what I was saying."
+        );
+        // Mid-sentence filler with surrounding pause commas: no doubled comma.
+        assert_eq!(
+            filter.filter("I was, uh, thinking about it."),
+            "I was, thinking about it."
         );
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,7 @@
         "label": "main",
         "title": "Thoth",
         "width": 1100,
-        "height": 1000,
+        "height": 1200,
         "minWidth": 980,
         "minHeight": 700,
         "visible": true,
@@ -68,7 +68,9 @@
     },
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEExOEY5RURGQUJBNkQzRjkKUldUNTA2YXIzNTZQb1lNSGQ3WVlkbDY3VVlUQlJYSzJzQW5ieUhhci9NVnVDUms5T0NJa21acnEK",
-      "endpoints": ["https://github.com/poodle64/thoth/releases/latest/download/latest.json"]
+      "endpoints": [
+        "https://github.com/poodle64/thoth/releases/latest/download/latest.json"
+      ]
     }
   },
   "bundle": {
@@ -108,8 +110,17 @@
         "bundleMediaFramework": true
       },
       "deb": {
-        "depends": ["libasound2", "libwebkit2gtk-4.1-0", "libgtk-3-0", "libvulkan1"],
-        "recommends": ["wtype", "xdg-utils", "libayatana-appindicator3-1"],
+        "depends": [
+          "libasound2",
+          "libwebkit2gtk-4.1-0",
+          "libgtk-3-0",
+          "libvulkan1"
+        ],
+        "recommends": [
+          "wtype",
+          "xdg-utils",
+          "libayatana-appindicator3-1"
+        ],
         "section": "sound",
         "priority": "optional",
         "desktopTemplate": "linux/thoth.desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,8 +15,10 @@
       {
         "label": "main",
         "title": "Thoth",
-        "width": 900,
+        "width": 1100,
         "height": 1000,
+        "minWidth": 980,
+        "minHeight": 700,
         "visible": true,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -64,7 +64,7 @@
           debug('Model downloaded:', modelDownloaded);
 
           if (modelDownloaded) {
-            await invoke('init_transcription', { model_path: modelDir });
+            await invoke('init_transcription', { modelPath: modelDir });
             debug('Transcription service ready');
           }
         }

--- a/src/lib/components/InsightsPane.svelte
+++ b/src/lib/components/InsightsPane.svelte
@@ -26,6 +26,7 @@
   import { Button } from '$components/ui/button';
   import { Checkbox } from '$components/ui/checkbox';
   import { formatBytes, formatTotalDuration } from '../utils/format';
+  import { friendlyModelName } from '../utils/model-name';
   import Flame from '@lucide/svelte/icons/flame';
   import Trash2 from '@lucide/svelte/icons/trash-2';
   import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
@@ -146,11 +147,27 @@
   );
   const cruftSomeSelected = $derived(cruftSelectedIds.size > 0 && !cruftAllSelected);
 
+  const MONTH_ABBREVS = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+
   const heatmapData = $derived.by(() => {
     if (!data?.activity?.length)
       return {
         weeks: [] as Array<Array<{ day: string; count: number; words: number } | null>>,
         max: 1,
+        monthLabels: [] as Array<{ label: string; weekIndex: number }>,
       };
     const byDay = new Map(data.activity.map((d) => [d.day, d]));
 
@@ -161,8 +178,25 @@
 
     const weeks: Array<Array<{ day: string; count: number; words: number } | null>> = [];
     const cursor = new Date(start);
+    let weekIndex = 0;
+    // Track which months we've already placed a label for
+    const seenMonths = new Set<number>();
+    const monthLabels: Array<{ label: string; weekIndex: number }> = [];
+
     while (cursor <= today) {
       const week: Array<{ day: string; count: number; words: number } | null> = [];
+      // Check the Sunday (first day of week) for month boundary
+      const sundayMonth = cursor.getMonth();
+      const sundayYear = cursor.getFullYear();
+      const monthKey = sundayYear * 12 + sundayMonth;
+      if (!seenMonths.has(monthKey)) {
+        seenMonths.add(monthKey);
+        // Only label if not the very first partial week (to avoid clipping)
+        if (weekIndex > 0) {
+          monthLabels.push({ label: MONTH_ABBREVS[sundayMonth], weekIndex });
+        }
+      }
+
       for (let d = 0; d < 7; d++) {
         if (cursor > today) {
           week.push(null);
@@ -173,10 +207,11 @@
         cursor.setDate(cursor.getDate() + 1);
       }
       weeks.push(week);
+      weekIndex++;
     }
 
     const max = Math.max(1, ...data.activity.map((d) => d.count));
-    return { weeks, max };
+    return { weeks, max, monthLabels };
   });
 
   const peakHour = $derived.by(() => {
@@ -384,7 +419,10 @@
           <span class="text-[22px] font-semibold text-foreground tabular-nums leading-tight block">
             ≈{data.totals.totalWords.toLocaleString()}
           </span>
-          <span class="text-xs text-muted-foreground mt-1 block">Words dictated</span>
+          <span class="text-xs text-muted-foreground mt-1 block">
+            Words dictated
+            <span class="opacity-60">({data.totals.totalCount.toLocaleString()} recordings)</span>
+          </span>
         </Card.Content>
       </Card.Root>
       <Card.Root>
@@ -401,7 +439,7 @@
             {formatTotalDuration(data.totals.typingTimeSavedSeconds)}
           </span>
           <span class="text-xs text-muted-foreground mt-1 block">
-            Typing time saved <span class="opacity-60">@ 40 wpm</span>
+            Typing saved <span class="opacity-60">@ 40 wpm</span>
           </span>
         </Card.Content>
       </Card.Root>
@@ -414,7 +452,7 @@
             {data.currentStreak}d
           </span>
           <span class="text-xs text-muted-foreground mt-1 block">
-            Current streak <span class="opacity-60">longest {data.longestStreak}d</span>
+            Streak <span class="opacity-60">longest {data.longestStreak}d</span>
           </span>
         </Card.Content>
       </Card.Root>
@@ -425,27 +463,57 @@
   <section class="mb-6">
     <h3 class="text-sm font-semibold text-foreground mb-3">Activity</h3>
     <div class="rounded-md border border-border bg-card p-4 overflow-x-auto">
-      <div class="heatmap-grid">
-        {#each heatmapData.weeks as week}
-          <div class="heatmap-col">
-            {#each week as cell}
-              {#if cell === null}
-                <div class="heatmap-cell heatmap-cell--empty"></div>
-              {:else}
-                {@const intensity = heatmapData.max > 0 ? cell.count / heatmapData.max : 0}
-                <div
-                  class="heatmap-cell"
-                  style="--intensity: {intensity}"
-                  title="{cell.day}: {cell.count} recording{cell.count === 1
-                    ? ''
-                    : 's'}{cell.words > 0 ? `, ≈${cell.words.toLocaleString()} words` : ''}"
-                ></div>
-              {/if}
+      <!-- Month labels row + weekday gutter side-by-side -->
+      <div class="heatmap-outer">
+        <!-- Left gutter: weekday labels aligned to Mon/Wed/Fri rows -->
+        <div class="heatmap-day-labels" aria-hidden="true">
+          <!-- spacer for month-label row -->
+          <div class="heatmap-month-spacer"></div>
+          <span class="heatmap-day-label">Mon</span>
+          <span class="heatmap-day-label heatmap-day-label--hidden"></span>
+          <span class="heatmap-day-label">Wed</span>
+          <span class="heatmap-day-label heatmap-day-label--hidden"></span>
+          <span class="heatmap-day-label">Fri</span>
+          <span class="heatmap-day-label heatmap-day-label--hidden"></span>
+          <span class="heatmap-day-label heatmap-day-label--hidden"></span>
+        </div>
+
+        <!-- Right side: month labels + grid -->
+        <div class="heatmap-right">
+          <!-- Month label row — absolutely positioned over the grid -->
+          <div class="heatmap-month-row" aria-hidden="true">
+            {#each heatmapData.monthLabels as ml}
+              <span class="heatmap-month-label" style="left: calc({ml.weekIndex} * 12px)"
+                >{ml.label}</span
+              >
             {/each}
           </div>
-        {/each}
+
+          <!-- Cell grid -->
+          <div class="heatmap-grid">
+            {#each heatmapData.weeks as week}
+              <div class="heatmap-col">
+                {#each week as cell}
+                  {#if cell === null}
+                    <div class="heatmap-cell heatmap-cell--empty"></div>
+                  {:else}
+                    {@const intensity = heatmapData.max > 0 ? cell.count / heatmapData.max : 0}
+                    <div
+                      class="heatmap-cell"
+                      style="--intensity: {intensity}"
+                      title="{cell.day}: {cell.count} recording{cell.count === 1
+                        ? ''
+                        : 's'}{cell.words > 0 ? `, ≈${cell.words.toLocaleString()} words` : ''}"
+                    ></div>
+                  {/if}
+                {/each}
+              </div>
+            {/each}
+          </div>
+        </div>
       </div>
-      <div class="flex items-center gap-1.5 mt-2 justify-end">
+
+      <div class="flex items-center gap-1.5 mt-3 justify-end">
         <span class="text-[10px] text-muted-foreground">Less</span>
         <div class="heatmap-legend-cell" style="--intensity: 0"></div>
         <div class="heatmap-legend-cell" style="--intensity: 0.25"></div>
@@ -465,19 +533,25 @@
         <p class="text-xs text-muted-foreground mb-4">×realtime — higher is faster</p>
         <div class="flex flex-col gap-3">
           {#each data.throughput as row}
+            {@const displayName = friendlyModelName(row.name)}
             <div class="flex items-center gap-3">
-              <span class="text-xs text-muted-foreground w-28 shrink-0 truncate" title={row.name}>
-                {row.name}
+              <span
+                class="text-xs text-muted-foreground w-36 shrink-0 truncate"
+                title={displayName}
+              >
+                {displayName}
               </span>
-              <div class="flex-1 flex items-end gap-1 h-8">
+              <div class="flex-1 h-5">
                 <div
-                  class="rounded-sm transition-all"
+                  class="h-full rounded-sm"
                   style="width: {(row.speedFactor / maxThroughput) *
-                    100}%; height: 100%; background: var(--chart-1); min-width: 4px"
+                    100}%; background: var(--chart-1); min-width: 4px"
                 ></div>
               </div>
-              <span class="text-xs font-semibold text-foreground tabular-nums w-14 shrink-0">
-                {row.speedFactor.toFixed(0)}×
+              <span
+                class="text-xs font-semibold text-foreground tabular-nums w-12 text-right shrink-0"
+              >
+                {row.speedFactor >= 10 ? row.speedFactor.toFixed(0) : row.speedFactor.toFixed(1)}×
               </span>
             </div>
           {/each}
@@ -499,9 +573,13 @@
         </div>
         <div class="flex flex-col gap-2.5">
           {#each data.modelUsage.backendCounts as bc}
+            {@const displayName = friendlyModelName(bc.name)}
             <div class="flex items-center gap-3">
-              <span class="text-xs text-muted-foreground w-36 shrink-0 truncate" title={bc.name}>
-                {bc.name}
+              <span
+                class="text-xs text-muted-foreground w-36 shrink-0 truncate"
+                title={displayName}
+              >
+                {displayName}
               </span>
               <div class="flex-1 h-2 rounded-full bg-muted overflow-hidden">
                 <div
@@ -509,8 +587,8 @@
                   style="width: {(bc.count / maxBackendCount) * 100}%; background: var(--chart-1)"
                 ></div>
               </div>
-              <span class="text-xs text-foreground tabular-nums w-10 text-right shrink-0">
-                {bc.count}
+              <span class="text-xs text-foreground tabular-nums w-14 text-right shrink-0">
+                {bc.count.toLocaleString()}
               </span>
             </div>
           {/each}
@@ -828,10 +906,66 @@
 
 <style>
   /* GitHub-style contribution heatmap */
+
+  /* Outer wrapper: day-label gutter beside the grid+month-labels block */
+  .heatmap-outer {
+    display: flex;
+    align-items: flex-start;
+    gap: 4px;
+    min-width: max-content;
+  }
+
+  /* Left column: weekday labels */
+  .heatmap-day-labels {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding-top: 0; /* aligns with month-row + grid */
+  }
+
+  /* Spacer that matches the month-label row height */
+  .heatmap-month-spacer {
+    height: 14px;
+    display: block;
+  }
+
+  .heatmap-day-label {
+    height: 10px;
+    line-height: 10px;
+    font-size: 9px;
+    color: var(--muted-foreground);
+    white-space: nowrap;
+    display: block;
+  }
+
+  .heatmap-day-label--hidden {
+    visibility: hidden;
+  }
+
+  /* Right block: month labels above the grid */
+  .heatmap-right {
+    position: relative;
+  }
+
+  .heatmap-month-row {
+    position: relative;
+    height: 14px;
+    margin-bottom: 2px;
+  }
+
+  .heatmap-month-label {
+    position: absolute;
+    top: 0;
+    font-size: 9px;
+    color: var(--muted-foreground);
+    line-height: 1;
+    white-space: nowrap;
+    /* each week column is 12px (10px cell + 2px gap) */
+  }
+
   .heatmap-grid {
     display: flex;
     gap: 2px;
-    min-width: max-content;
   }
 
   .heatmap-col {

--- a/src/lib/components/InsightsPane.svelte
+++ b/src/lib/components/InsightsPane.svelte
@@ -1,0 +1,875 @@
+<script lang="ts">
+  /**
+   * Insights pane — rich stats dashboard for the heavy dictator.
+   *
+   * Sections:
+   *  1. Hero stat cards (words, audio time, typing saved, streak)
+   *  2. Activity heatmap (GitHub-style, CSS grid)
+   *  3. Throughput bar chart (CSS, speedFactor per backend)
+   *  4. Model usage (backend counts + enhanced %)
+   *  5. Recording length histogram (CSS bars)
+   *  6. Time of day (CSS bars, 24 buckets)
+   *  7. Cruft finder (multi-select, quarantine to reversible Trash)
+   *  8. Storage breakdown (segmented bar)
+   *
+   * LayerChart (installed as layerchart/d3-scale) was trialled but its
+   * SvelteComponentTyped-based Chart slot API is not compatible with Svelte 5
+   * strict-typed snippets. CSS flex bars provide equivalent readability
+   * for these simple distributions without the type friction.
+   */
+
+  import { onMount } from 'svelte';
+  import { invoke } from '@tauri-apps/api/core';
+  import { toast } from 'svelte-sonner';
+  import * as Card from '$components/ui/card';
+  import * as AlertDialog from '$components/ui/alert-dialog';
+  import { Button } from '$components/ui/button';
+  import { Checkbox } from '$components/ui/checkbox';
+  import { formatBytes, formatTotalDuration } from '../utils/format';
+  import Flame from '@lucide/svelte/icons/flame';
+  import Trash2 from '@lucide/svelte/icons/trash-2';
+  import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
+  import ChevronDown from '@lucide/svelte/icons/chevron-down';
+  import ChevronRight from '@lucide/svelte/icons/chevron-right';
+  import X from '@lucide/svelte/icons/x';
+
+  // ---------------------------------------------------------------------------
+  // Types
+  // ---------------------------------------------------------------------------
+
+  type Range = 'allTime' | 'year' | 'month' | 'week';
+
+  interface ActivityDay {
+    day: string;
+    count: number;
+    words: number;
+  }
+
+  interface ThroughputRow {
+    name: string;
+    count: number;
+    avgAudioDuration: number;
+    avgProcessingTime: number;
+    speedFactor: number;
+  }
+
+  interface ModelUsage {
+    backendCounts: Array<{ name: string; count: number }>;
+    enhancementPrompts: Array<{ prompt: string; count: number }>;
+    enhancedPct: number;
+  }
+
+  interface StorageInfo {
+    recordingsBytes: number;
+    modelsBytes: number;
+    dbBytes: number;
+    totalBytes: number;
+    oldestRecordingAt: string | null;
+  }
+
+  interface InsightsData {
+    totals: {
+      totalCount: number;
+      totalAudioSeconds: number;
+      totalWords: number;
+      enhancedCount: number;
+      typingTimeSavedSeconds: number;
+      firstRecordingAt: string | null;
+    };
+    activity: ActivityDay[];
+    currentStreak: number;
+    longestStreak: number;
+    throughput: ThroughputRow[];
+    modelUsage: ModelUsage;
+    lengthHistogram: Array<{ bucketLabel: string; count: number }>;
+    timeOfDay: number[];
+    storage: StorageInfo;
+  }
+
+  interface CruftCandidate {
+    id: string;
+    createdAt: string;
+    textPreview: string;
+    durationSeconds: number;
+    density: number;
+    audioPath: string | null;
+    fileBytes: number;
+    rms: number | null;
+  }
+
+  interface TrashEntry {
+    id: string;
+    textPreview: string;
+    createdAt: string;
+    deletedAt: string;
+    durationSeconds: number;
+    fileBytes: number;
+    audioMoved: boolean;
+  }
+
+  // ---------------------------------------------------------------------------
+  // State
+  // ---------------------------------------------------------------------------
+
+  let range = $state<Range>('allTime');
+  let data = $state<InsightsData | null>(null);
+  let isLoading = $state(true);
+  let loadError = $state<string | null>(null);
+
+  let cruftCandidates = $state<CruftCandidate[]>([]);
+  let cruftLoading = $state(false);
+  let cruftLoaded = $state(false);
+  let cruftSelectedIds = $state(new Set<string>());
+  let quarantineConfirm = $state(false);
+
+  let trashEntries = $state<TrashEntry[]>([]);
+  let trashOpen = $state(false);
+  let trashLoading = $state(false);
+
+  // Track whether we've done the initial load so $effect doesn't double-fire
+  let initialLoadDone = $state(false);
+
+  const RANGES: Array<{ value: Range; label: string }> = [
+    { value: 'allTime', label: 'All time' },
+    { value: 'year', label: 'This year' },
+    { value: 'month', label: 'This month' },
+    { value: 'week', label: 'This week' },
+  ];
+
+  // ---------------------------------------------------------------------------
+  // Derived
+  // ---------------------------------------------------------------------------
+
+  const cruftBulkMode = $derived(cruftSelectedIds.size > 0);
+  const cruftAllSelected = $derived(
+    cruftCandidates.length > 0 && cruftSelectedIds.size === cruftCandidates.length
+  );
+  const cruftSomeSelected = $derived(cruftSelectedIds.size > 0 && !cruftAllSelected);
+
+  const heatmapData = $derived.by(() => {
+    if (!data?.activity?.length)
+      return {
+        weeks: [] as Array<Array<{ day: string; count: number; words: number } | null>>,
+        max: 1,
+      };
+    const byDay = new Map(data.activity.map((d) => [d.day, d]));
+
+    const today = new Date();
+    const start = new Date(today);
+    start.setDate(start.getDate() - 364);
+    start.setDate(start.getDate() - start.getDay()); // align to Sunday
+
+    const weeks: Array<Array<{ day: string; count: number; words: number } | null>> = [];
+    const cursor = new Date(start);
+    while (cursor <= today) {
+      const week: Array<{ day: string; count: number; words: number } | null> = [];
+      for (let d = 0; d < 7; d++) {
+        if (cursor > today) {
+          week.push(null);
+        } else {
+          const key = cursor.toISOString().slice(0, 10);
+          week.push(byDay.get(key) ?? { day: key, count: 0, words: 0 });
+        }
+        cursor.setDate(cursor.getDate() + 1);
+      }
+      weeks.push(week);
+    }
+
+    const max = Math.max(1, ...data.activity.map((d) => d.count));
+    return { weeks, max };
+  });
+
+  const peakHour = $derived.by(() => {
+    if (!data?.timeOfDay?.length) return 0;
+    let peak = 0;
+    let peakIdx = 0;
+    data.timeOfDay.forEach((v, i) => {
+      if (v > peak) {
+        peak = v;
+        peakIdx = i;
+      }
+    });
+    return peakIdx;
+  });
+
+  const maxTimeOfDay = $derived(data?.timeOfDay ? Math.max(1, ...data.timeOfDay) : 1);
+
+  const maxThroughput = $derived(
+    data?.throughput ? Math.max(1, ...data.throughput.map((r) => r.speedFactor)) : 1
+  );
+
+  const maxHistogram = $derived(
+    data?.lengthHistogram ? Math.max(1, ...data.lengthHistogram.map((r) => r.count)) : 1
+  );
+
+  const maxBackendCount = $derived(
+    data?.modelUsage ? Math.max(1, ...data.modelUsage.backendCounts.map((b) => b.count)) : 1
+  );
+
+  const storageSegments = $derived.by(() => {
+    if (!data?.storage)
+      return [] as Array<{ label: string; bytes: number; pct: number; color: string }>;
+    const { recordingsBytes, modelsBytes, dbBytes } = data.storage;
+    const total = recordingsBytes + modelsBytes + dbBytes || 1;
+    return [
+      {
+        label: 'Recordings',
+        bytes: recordingsBytes,
+        pct: (recordingsBytes / total) * 100,
+        color: 'var(--chart-1)',
+      },
+      {
+        label: 'Models',
+        bytes: modelsBytes,
+        pct: (modelsBytes / total) * 100,
+        color: 'var(--chart-2)',
+      },
+      { label: 'Database', bytes: dbBytes, pct: (dbBytes / total) * 100, color: 'var(--chart-5)' },
+    ];
+  });
+
+  // ---------------------------------------------------------------------------
+  // Load
+  // ---------------------------------------------------------------------------
+
+  async function loadInsights() {
+    isLoading = true;
+    loadError = null;
+    try {
+      data = await invoke<InsightsData>('get_insights', { range });
+    } catch (e) {
+      loadError = e instanceof Error ? e.message : String(e);
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  async function loadCruft() {
+    cruftLoading = true;
+    try {
+      cruftCandidates = await invoke<CruftCandidate[]>('get_cruft_candidates');
+      cruftLoaded = true;
+    } catch (e) {
+      toast.error(`Cruft scan failed: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      cruftLoading = false;
+    }
+  }
+
+  async function loadTrash() {
+    trashLoading = true;
+    try {
+      trashEntries = await invoke<TrashEntry[]>('list_trash');
+    } catch (e) {
+      toast.error(`Failed to load trash: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      trashLoading = false;
+    }
+  }
+
+  async function confirmQuarantine() {
+    const ids = [...cruftSelectedIds];
+    try {
+      const count = await invoke<number>('quarantine_recordings', { ids });
+      toast.success(`Moved ${count} recording${count === 1 ? '' : 's'} to Trash (reversible)`);
+      cruftSelectedIds = new Set();
+      quarantineConfirm = false;
+      await loadCruft();
+      if (trashOpen) await loadTrash();
+    } catch (e) {
+      toast.error(`Failed to quarantine: ${e instanceof Error ? e.message : String(e)}`);
+      quarantineConfirm = false;
+    }
+  }
+
+  async function handleRestore(id: string) {
+    try {
+      await invoke('restore_recordings', { ids: [id] });
+      toast.success('Restored');
+      await loadTrash();
+    } catch (e) {
+      toast.error(`Restore failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  async function handlePurge(id: string) {
+    try {
+      await invoke('purge_trash', { ids: [id] });
+      toast.success('Permanently deleted');
+      await loadTrash();
+    } catch (e) {
+      toast.error(`Purge failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  // Cruft bulk-select helpers (matches HistoryPane pattern: new Set() reassign for reactivity)
+  function toggleCruftItem(id: string) {
+    const next = new Set(cruftSelectedIds);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    cruftSelectedIds = next;
+  }
+
+  function selectAllCruft() {
+    cruftSelectedIds = new Set(cruftCandidates.map((c) => c.id));
+  }
+
+  function deselectAllCruft() {
+    cruftSelectedIds = new Set();
+  }
+
+  function formatHour(h: number): string {
+    if (h === 0) return '12am';
+    if (h < 12) return `${h}am`;
+    if (h === 12) return '12pm';
+    return `${h - 12}pm`;
+  }
+
+  function formatDate(iso: string): string {
+    return new Date(iso).toLocaleDateString('en-AU', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    });
+  }
+
+  onMount(() => {
+    loadInsights().then(() => {
+      initialLoadDone = true;
+    });
+  });
+
+  $effect(() => {
+    // Re-fetch when range changes, but not on initial mount (onMount handles that)
+    if (!initialLoadDone) return;
+    void range;
+    loadInsights();
+  });
+</script>
+
+<!-- Page header with range selector -->
+<div class="flex items-center justify-between mb-6">
+  <h2 class="text-base font-semibold text-foreground m-0">Insights</h2>
+  <div class="flex items-center gap-1 rounded-md border border-border bg-card p-1">
+    {#each RANGES as r}
+      <button
+        class="px-3 py-1 rounded text-xs font-medium transition-colors {range === r.value
+          ? 'bg-primary text-primary-foreground'
+          : 'text-muted-foreground hover:text-foreground'}"
+        onclick={() => (range = r.value)}
+      >
+        {r.label}
+      </button>
+    {/each}
+  </div>
+</div>
+
+{#if isLoading}
+  <div class="flex items-center justify-center py-16 text-muted-foreground text-sm">Loading…</div>
+{:else if loadError}
+  <div
+    class="rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+  >
+    {loadError}
+  </div>
+{:else if data}
+  <!-- 1. Hero stat cards -->
+  <section class="mb-6">
+    <div class="grid grid-cols-2 gap-2.5">
+      <Card.Root>
+        <Card.Content class="p-4">
+          <span class="text-[22px] font-semibold text-foreground tabular-nums leading-tight block">
+            ≈{data.totals.totalWords.toLocaleString()}
+          </span>
+          <span class="text-xs text-muted-foreground mt-1 block">Words dictated</span>
+        </Card.Content>
+      </Card.Root>
+      <Card.Root>
+        <Card.Content class="p-4">
+          <span class="text-[22px] font-semibold text-foreground tabular-nums leading-tight block">
+            {formatTotalDuration(data.totals.totalAudioSeconds)}
+          </span>
+          <span class="text-xs text-muted-foreground mt-1 block">Audio recorded</span>
+        </Card.Content>
+      </Card.Root>
+      <Card.Root>
+        <Card.Content class="p-4">
+          <span class="text-[22px] font-semibold text-foreground tabular-nums leading-tight block">
+            {formatTotalDuration(data.totals.typingTimeSavedSeconds)}
+          </span>
+          <span class="text-xs text-muted-foreground mt-1 block">
+            Typing time saved <span class="opacity-60">@ 40 wpm</span>
+          </span>
+        </Card.Content>
+      </Card.Root>
+      <Card.Root>
+        <Card.Content class="p-4">
+          <span
+            class="text-[22px] font-semibold text-foreground tabular-nums flex items-center gap-1.5 leading-tight"
+          >
+            <Flame class="size-5 text-chart-1 shrink-0" />
+            {data.currentStreak}d
+          </span>
+          <span class="text-xs text-muted-foreground mt-1 block">
+            Current streak <span class="opacity-60">longest {data.longestStreak}d</span>
+          </span>
+        </Card.Content>
+      </Card.Root>
+    </div>
+  </section>
+
+  <!-- 2. Activity heatmap -->
+  <section class="mb-6">
+    <h3 class="text-sm font-semibold text-foreground mb-3">Activity</h3>
+    <div class="rounded-md border border-border bg-card p-4 overflow-x-auto">
+      <div class="heatmap-grid">
+        {#each heatmapData.weeks as week}
+          <div class="heatmap-col">
+            {#each week as cell}
+              {#if cell === null}
+                <div class="heatmap-cell heatmap-cell--empty"></div>
+              {:else}
+                {@const intensity = heatmapData.max > 0 ? cell.count / heatmapData.max : 0}
+                <div
+                  class="heatmap-cell"
+                  style="--intensity: {intensity}"
+                  title="{cell.day}: {cell.count} recording{cell.count === 1
+                    ? ''
+                    : 's'}{cell.words > 0 ? `, ≈${cell.words.toLocaleString()} words` : ''}"
+                ></div>
+              {/if}
+            {/each}
+          </div>
+        {/each}
+      </div>
+      <div class="flex items-center gap-1.5 mt-2 justify-end">
+        <span class="text-[10px] text-muted-foreground">Less</span>
+        <div class="heatmap-legend-cell" style="--intensity: 0"></div>
+        <div class="heatmap-legend-cell" style="--intensity: 0.25"></div>
+        <div class="heatmap-legend-cell" style="--intensity: 0.5"></div>
+        <div class="heatmap-legend-cell" style="--intensity: 0.75"></div>
+        <div class="heatmap-legend-cell" style="--intensity: 1"></div>
+        <span class="text-[10px] text-muted-foreground">More</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- 3. Throughput -->
+  {#if data.throughput.length > 0}
+    <section class="mb-6">
+      <h3 class="text-sm font-semibold text-foreground mb-3">Transcription speed</h3>
+      <div class="rounded-md border border-border bg-card p-4">
+        <p class="text-xs text-muted-foreground mb-4">×realtime — higher is faster</p>
+        <div class="flex flex-col gap-3">
+          {#each data.throughput as row}
+            <div class="flex items-center gap-3">
+              <span class="text-xs text-muted-foreground w-28 shrink-0 truncate" title={row.name}>
+                {row.name}
+              </span>
+              <div class="flex-1 flex items-end gap-1 h-8">
+                <div
+                  class="rounded-sm transition-all"
+                  style="width: {(row.speedFactor / maxThroughput) *
+                    100}%; height: 100%; background: var(--chart-1); min-width: 4px"
+                ></div>
+              </div>
+              <span class="text-xs font-semibold text-foreground tabular-nums w-14 shrink-0">
+                {row.speedFactor.toFixed(0)}×
+              </span>
+            </div>
+          {/each}
+        </div>
+      </div>
+    </section>
+  {/if}
+
+  <!-- 4. Model usage -->
+  {#if data.modelUsage.backendCounts.length > 0}
+    <section class="mb-6">
+      <h3 class="text-sm font-semibold text-foreground mb-3">Model usage</h3>
+      <div class="rounded-md border border-border bg-card p-4">
+        <div class="flex items-baseline gap-2 mb-4">
+          <span class="text-[28px] font-semibold text-foreground tabular-nums leading-none">
+            {data.modelUsage.enhancedPct.toFixed(0)}%
+          </span>
+          <span class="text-xs text-muted-foreground">enhanced with AI</span>
+        </div>
+        <div class="flex flex-col gap-2.5">
+          {#each data.modelUsage.backendCounts as bc}
+            <div class="flex items-center gap-3">
+              <span class="text-xs text-muted-foreground w-36 shrink-0 truncate" title={bc.name}>
+                {bc.name}
+              </span>
+              <div class="flex-1 h-2 rounded-full bg-muted overflow-hidden">
+                <div
+                  class="h-full rounded-full"
+                  style="width: {(bc.count / maxBackendCount) * 100}%; background: var(--chart-1)"
+                ></div>
+              </div>
+              <span class="text-xs text-foreground tabular-nums w-10 text-right shrink-0">
+                {bc.count}
+              </span>
+            </div>
+          {/each}
+        </div>
+      </div>
+    </section>
+  {/if}
+
+  <!-- 5. Recording length histogram -->
+  {#if data.lengthHistogram.length > 0}
+    <section class="mb-6">
+      <h3 class="text-sm font-semibold text-foreground mb-3">Recording length</h3>
+      <div class="rounded-md border border-border bg-card p-4">
+        <div class="flex items-end gap-1.5 h-28">
+          {#each data.lengthHistogram as bucket}
+            <div class="flex flex-col items-center gap-1 flex-1">
+              <div
+                class="w-full rounded-t-sm"
+                style="height: {(bucket.count / maxHistogram) *
+                  88}px; background: var(--chart-2); min-height: {bucket.count > 0 ? '3' : '0'}px"
+                title="{bucket.bucketLabel}: {bucket.count}"
+              ></div>
+              <span class="text-[9px] text-muted-foreground text-center leading-tight">
+                {bucket.bucketLabel}
+              </span>
+            </div>
+          {/each}
+        </div>
+      </div>
+    </section>
+  {/if}
+
+  <!-- 6. Time of day -->
+  {#if data.timeOfDay.length === 24}
+    <section class="mb-6">
+      <h3 class="text-sm font-semibold text-foreground mb-3">Time of day</h3>
+      <div class="rounded-md border border-border bg-card p-4">
+        <p class="text-xs text-muted-foreground mb-3">Peak: {formatHour(peakHour)}</p>
+        <div class="flex items-end gap-px h-20">
+          {#each data.timeOfDay as count, i}
+            <div
+              class="flex-1 rounded-t-sm transition-colors"
+              style="height: {(count / maxTimeOfDay) * 64}px; background: {i === peakHour
+                ? 'var(--chart-1)'
+                : 'var(--chart-5)'}; min-height: {count > 0 ? '2' : '0'}px"
+              title="{formatHour(i)}: {count}"
+            ></div>
+          {/each}
+        </div>
+        <div class="flex justify-between mt-1">
+          {#each [0, 6, 12, 18] as tick}
+            <span class="text-[10px] text-muted-foreground">{formatHour(tick)}</span>
+          {/each}
+        </div>
+      </div>
+    </section>
+  {/if}
+
+  <!-- 7. Cruft finder -->
+  <section class="mb-6">
+    <h3 class="text-sm font-semibold text-foreground mb-3">Cruft finder</h3>
+    <div class="rounded-md border border-border bg-card p-4">
+      <p class="text-xs text-muted-foreground mb-4 leading-snug">
+        Flags recordings by <strong class="text-foreground">density</strong> (characters per second)
+        — short, low-content dictations. Moving to Trash is
+        <strong class="text-foreground">reversible</strong>; restore or permanently delete from the
+        Trash section below.
+      </p>
+
+      {#if !cruftLoaded}
+        <Button
+          variant="outline"
+          size="sm"
+          onclick={loadCruft}
+          disabled={cruftLoading}
+          class="mb-2"
+        >
+          {cruftLoading ? 'Scanning…' : 'Scan for cruft'}
+        </Button>
+      {:else}
+        <!-- Cruft toolbar -->
+        {#if cruftBulkMode}
+          <div class="flex items-center gap-2 mb-3 px-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              onclick={cruftAllSelected ? deselectAllCruft : selectAllCruft}
+              class="h-7 w-7"
+              title={cruftAllSelected ? 'Deselect all' : 'Select all'}
+            >
+              <Checkbox
+                checked={cruftAllSelected}
+                indeterminate={cruftSomeSelected}
+                class="pointer-events-none"
+              />
+            </Button>
+            <span class="text-sm font-medium text-primary">{cruftSelectedIds.size} selected</span>
+            <div class="flex-1"></div>
+            <Button
+              variant="destructive"
+              size="sm"
+              onclick={() => (quarantineConfirm = true)}
+              class="h-7 gap-1.5 text-xs"
+            >
+              <Trash2 class="size-3.5" />
+              Move {cruftSelectedIds.size} to Trash
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onclick={deselectAllCruft}
+              class="h-7 w-7"
+              title="Cancel selection"
+            >
+              <X class="size-4" />
+            </Button>
+          </div>
+        {:else}
+          <div class="flex items-center gap-2 mb-3 px-1">
+            <span class="text-xs text-muted-foreground">
+              {cruftCandidates.length === 0
+                ? 'No cruft found'
+                : `${cruftCandidates.length} candidate${cruftCandidates.length === 1 ? '' : 's'} found`}
+            </span>
+            <div class="flex-1"></div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onclick={loadCruft}
+              disabled={cruftLoading}
+              class="h-7 text-xs"
+            >
+              Rescan
+            </Button>
+          </div>
+        {/if}
+
+        {#if cruftCandidates.length > 0}
+          <div class="flex flex-col gap-1">
+            {#each cruftCandidates as candidate}
+              {@const selected = cruftSelectedIds.has(candidate.id)}
+              <!-- svelte-ignore a11y_click_events_have_key_events -->
+              <!-- svelte-ignore a11y_no_static_element_interactions -->
+              <div
+                class="flex items-start gap-3 rounded-md border px-3 py-2.5 cursor-pointer transition-colors {selected
+                  ? 'border-primary/50 bg-primary/5'
+                  : 'border-border hover:bg-muted/40'}"
+                onclick={() => toggleCruftItem(candidate.id)}
+              >
+                <Checkbox checked={selected} class="mt-0.5 pointer-events-none shrink-0" />
+                <div class="flex-1 min-w-0">
+                  {#if candidate.textPreview.trim()}
+                    <p class="text-sm text-foreground truncate mb-1">{candidate.textPreview}</p>
+                  {:else}
+                    <p class="text-sm text-muted-foreground italic truncate mb-1">(no speech)</p>
+                  {/if}
+                  <div class="flex items-center gap-3 flex-wrap">
+                    <span class="text-[11px] text-muted-foreground">
+                      {formatDate(candidate.createdAt)}
+                    </span>
+                    <span class="text-[11px] font-mono text-chart-3">
+                      {candidate.density.toFixed(1)} c/s
+                    </span>
+                    {#if candidate.rms !== null}
+                      <span class="text-[11px] text-muted-foreground">
+                        rms {(candidate.rms * 100).toFixed(0)}%
+                      </span>
+                    {/if}
+                    <span class="text-[11px] text-muted-foreground">
+                      {formatTotalDuration(candidate.durationSeconds)}
+                    </span>
+                    {#if candidate.fileBytes > 0}
+                      <span class="text-[11px] text-muted-foreground">
+                        {formatBytes(candidate.fileBytes)}
+                      </span>
+                    {/if}
+                  </div>
+                </div>
+              </div>
+            {/each}
+          </div>
+        {/if}
+      {/if}
+
+      <!-- Trash disclosure -->
+      <div class="mt-4 border-t border-border pt-3">
+        <button
+          class="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          onclick={() => {
+            trashOpen = !trashOpen;
+            if (trashOpen && trashEntries.length === 0) loadTrash();
+          }}
+        >
+          {#if trashOpen}
+            <ChevronDown class="size-3.5" />
+          {:else}
+            <ChevronRight class="size-3.5" />
+          {/if}
+          Trash (reversible)
+        </button>
+        {#if trashOpen}
+          <div class="mt-3">
+            {#if trashLoading}
+              <p class="text-xs text-muted-foreground">Loading…</p>
+            {:else if trashEntries.length === 0}
+              <p class="text-xs text-muted-foreground">Trash is empty.</p>
+            {:else}
+              <div class="flex flex-col gap-1">
+                {#each trashEntries as entry}
+                  <div class="flex items-center gap-3 rounded-md border border-border px-3 py-2">
+                    <div class="flex-1 min-w-0">
+                      <p class="text-xs text-foreground truncate">{entry.textPreview}</p>
+                      <p class="text-[10px] text-muted-foreground mt-0.5">
+                        {formatDate(entry.createdAt)} · deleted {formatDate(entry.deletedAt)} · {formatBytes(
+                          entry.fileBytes
+                        )}
+                      </p>
+                    </div>
+                    <div class="flex items-center gap-1 shrink-0">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onclick={() => handleRestore(entry.id)}
+                        class="h-6 text-[11px] gap-1"
+                        title="Restore"
+                      >
+                        <RotateCcw class="size-3" />
+                        Restore
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onclick={() => handlePurge(entry.id)}
+                        class="h-6 text-[11px] text-destructive hover:text-destructive hover:bg-destructive/10"
+                        title="Delete permanently"
+                      >
+                        <Trash2 class="size-3" />
+                      </Button>
+                    </div>
+                  </div>
+                {/each}
+              </div>
+            {/if}
+          </div>
+        {/if}
+      </div>
+    </div>
+  </section>
+
+  <!-- 8. Storage -->
+  <section class="mb-6">
+    <h3 class="text-sm font-semibold text-foreground mb-3">Storage</h3>
+    <div class="rounded-md border border-border bg-card p-4">
+      <div class="flex items-baseline gap-2 mb-3">
+        <span class="text-[22px] font-semibold text-foreground tabular-nums">
+          {formatBytes(data.storage.totalBytes)}
+        </span>
+        <span class="text-xs text-muted-foreground">total</span>
+      </div>
+      <!-- Segmented bar -->
+      <div class="flex h-3 rounded-full overflow-hidden gap-0.5 mb-3">
+        {#each storageSegments as seg}
+          {#if seg.pct > 0.5}
+            <div
+              class="h-full rounded-full"
+              style="width: {seg.pct}%; background: {seg.color}; min-width: 4px"
+              title="{seg.label}: {formatBytes(seg.bytes)}"
+            ></div>
+          {/if}
+        {/each}
+      </div>
+      <div class="flex flex-col gap-1.5">
+        {#each storageSegments as seg}
+          <div class="flex items-center gap-2">
+            <span class="w-2 h-2 rounded-full shrink-0" style="background: {seg.color}"></span>
+            <span class="text-xs text-muted-foreground w-20 shrink-0">{seg.label}</span>
+            <span class="text-xs text-foreground tabular-nums">{formatBytes(seg.bytes)}</span>
+          </div>
+        {/each}
+      </div>
+      {#if data.storage.oldestRecordingAt}
+        <p class="text-[11px] text-muted-foreground mt-3">
+          Oldest recording: {formatDate(data.storage.oldestRecordingAt)}
+        </p>
+      {/if}
+    </div>
+  </section>
+{/if}
+
+<!-- Quarantine confirm dialog -->
+<AlertDialog.Root
+  open={quarantineConfirm}
+  onOpenChange={(open) => {
+    if (!open) quarantineConfirm = false;
+  }}
+>
+  <AlertDialog.Content>
+    <AlertDialog.Header>
+      <AlertDialog.Title>
+        Move {cruftSelectedIds.size} recording{cruftSelectedIds.size === 1 ? '' : 's'} to Trash?
+      </AlertDialog.Title>
+      <AlertDialog.Description>
+        Flagged by density, not length. This is <strong>reversible</strong> — restore from the Trash section
+        at any time. Audio files are moved, not deleted.
+      </AlertDialog.Description>
+    </AlertDialog.Header>
+    <AlertDialog.Footer>
+      <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+      <AlertDialog.Action onclick={confirmQuarantine} variant="destructive">
+        Move to Trash
+      </AlertDialog.Action>
+    </AlertDialog.Footer>
+  </AlertDialog.Content>
+</AlertDialog.Root>
+
+<style>
+  /* GitHub-style contribution heatmap */
+  .heatmap-grid {
+    display: flex;
+    gap: 2px;
+    min-width: max-content;
+  }
+
+  .heatmap-col {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .heatmap-cell {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    /* intensity 0 → muted tone; intensity 1 → full chart-1 amber */
+    background: color-mix(
+      in srgb,
+      var(--chart-1) calc(var(--intensity, 0) * 75% + 5%),
+      var(--muted)
+    );
+    transition: opacity 100ms;
+  }
+
+  .heatmap-cell--empty {
+    background: transparent;
+  }
+
+  .heatmap-cell:not(.heatmap-cell--empty):hover {
+    outline: 1px solid var(--primary);
+    outline-offset: 1px;
+  }
+
+  .heatmap-legend-cell {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    background: color-mix(
+      in srgb,
+      var(--chart-1) calc(var(--intensity, 0) * 75% + 5%),
+      var(--muted)
+    );
+  }
+</style>

--- a/src/lib/components/InsightsPane.svelte
+++ b/src/lib/components/InsightsPane.svelte
@@ -103,7 +103,7 @@
     textPreview: string;
     createdAt: string;
     deletedAt: string;
-    durationSeconds: number;
+    durationSeconds: number | null;
     fileBytes: number;
     audioMoved: boolean;
   }
@@ -127,8 +127,9 @@
   let trashOpen = $state(false);
   let trashLoading = $state(false);
 
-  // Track whether we've done the initial load so $effect doesn't double-fire
-  let initialLoadDone = $state(false);
+  // Track whether we've done the initial load so $effect doesn't double-fire.
+  // Plain let (not $state) so reading it inside $effect doesn't create a tracked dep.
+  let initialLoadDone = false;
 
   const RANGES: Array<{ value: Range; label: string }> = [
     { value: 'allTime', label: 'All time' },
@@ -201,7 +202,11 @@
         if (cursor > today) {
           week.push(null);
         } else {
-          const key = cursor.toISOString().slice(0, 10);
+          const key = [
+            cursor.getFullYear(),
+            String(cursor.getMonth() + 1).padStart(2, '0'),
+            String(cursor.getDate()).padStart(2, '0'),
+          ].join('-');
           week.push(byDay.get(key) ?? { day: key, count: 0, words: 0 });
         }
         cursor.setDate(cursor.getDate() + 1);
@@ -380,7 +385,7 @@
   $effect(() => {
     // Re-fetch when range changes, but not on initial mount (onMount handles that)
     if (!initialLoadDone) return;
-    void range;
+    void range; // intentional reactive read — makes the effect re-run when range changes
     loadInsights();
   });
 </script>

--- a/src/lib/components/InsightsPane.svelte
+++ b/src/lib/components/InsightsPane.svelte
@@ -638,9 +638,14 @@
             ></div>
           {/each}
         </div>
-        <div class="flex justify-between mt-1">
-          {#each [0, 6, 12, 18] as tick}
-            <span class="text-[10px] text-muted-foreground">{formatHour(tick)}</span>
+        <!-- Labels share the bars' 24-cell flex layout so each tick sits
+             directly under its hour bar (a 4-up justify-between row drifts
+             out of alignment with the 24 bars). -->
+        <div class="flex gap-px mt-1">
+          {#each data.timeOfDay as _, i}
+            <span class="flex-1 text-center text-[10px] text-muted-foreground">
+              {i % 6 === 0 ? formatHour(i) : ''}
+            </span>
           {/each}
         </div>
       </div>

--- a/src/lib/components/IntegrationsSettings.svelte
+++ b/src/lib/components/IntegrationsSettings.svelte
@@ -7,6 +7,7 @@
   import { Button } from '$components/ui/button';
   import { Input } from '$components/ui/input';
   import * as AlertDialog from '$components/ui/alert-dialog';
+  import LoggingTelemetrySettings from './LoggingTelemetrySettings.svelte';
   import Eye from '@lucide/svelte/icons/eye';
   import EyeOff from '@lucide/svelte/icons/eye-off';
   import Copy from '@lucide/svelte/icons/copy';
@@ -123,7 +124,9 @@
   </div>
   <div class="flex flex-col gap-2">
     <!-- Enable API row -->
-    <div class="flex items-center justify-between gap-4 rounded-md border border-border bg-card p-3">
+    <div
+      class="flex items-center justify-between gap-4 rounded-md border border-border bg-card p-3"
+    >
       <div class="flex flex-1 flex-col gap-1">
         <span class="text-sm font-medium text-foreground">Enable API server</span>
         <span class="text-xs text-muted-foreground flex items-center gap-1.5">
@@ -139,10 +142,7 @@
           {/if}
         </span>
       </div>
-      <Switch
-        checked={status.apiEnabled}
-        onCheckedChange={handleApiToggle}
-      />
+      <Switch checked={status.apiEnabled} onCheckedChange={handleApiToggle} />
     </div>
 
     <!-- Token management — only shown when API is enabled and token exists -->
@@ -213,7 +213,9 @@
     </p>
   </div>
   <div class="flex flex-col gap-2">
-    <div class="flex items-center justify-between gap-4 rounded-md border border-border bg-card p-3">
+    <div
+      class="flex items-center justify-between gap-4 rounded-md border border-border bg-card p-3"
+    >
       <div class="flex flex-1 flex-col gap-1">
         <span class="text-sm font-medium text-foreground">Enable MCP server</span>
         {#if status.mcpEnabled && status.apiRunning}
@@ -236,6 +238,8 @@
     {/if}
   </div>
 </section>
+
+<LoggingTelemetrySettings />
 
 <!-- Rotate token confirmation dialog -->
 <AlertDialog.Root

--- a/src/lib/components/LoggingTelemetrySettings.svelte
+++ b/src/lib/components/LoggingTelemetrySettings.svelte
@@ -184,10 +184,14 @@
             value={configStore.logging.lokiAuth}
             oninput={handleLokiAuthInput}
             onblur={handleLokiAuthBlur}
-            placeholder="Bearer token (optional)"
+            placeholder="Paste your token"
             autocomplete="off"
             aria-label="Loki bearer token"
           />
+          <p class="text-xs text-muted-foreground">
+            Just the token — <span class="font-mono">Bearer</span> is added automatically. Paste a full
+            <span class="font-mono">Bearer …</span> or <span class="font-mono">Basic …</span> value to override.
+          </p>
         </div>
 
         <!-- Tenant ID (optional) -->

--- a/src/lib/components/LoggingTelemetrySettings.svelte
+++ b/src/lib/components/LoggingTelemetrySettings.svelte
@@ -189,8 +189,10 @@
             aria-label="Loki bearer token"
           />
           <p class="text-xs text-muted-foreground">
-            Just the token — <span class="font-mono">Bearer</span> is added automatically. Paste a full
-            <span class="font-mono">Bearer …</span> or <span class="font-mono">Basic …</span> value to override.
+            Just the token — <span class="font-mono">Bearer</span> is added automatically. Paste a
+            full
+            <span class="font-mono">Bearer …</span> or <span class="font-mono">Basic …</span> value to
+            override.
           </p>
         </div>
 
@@ -225,10 +227,11 @@
       </div>
     {/if}
 
-    <!-- Privacy note -->
+    <!-- Privacy + save note -->
     <p class="text-xs text-muted-foreground px-1">
-      Only content-free operational events are sent (timings, errors, model names) — never your
-      transcript text. Changes apply after restart.
+      Settings save automatically — there's no save button. Only content-free operational events are
+      sent (timings, errors, model names) — never your transcript text. Remote forwarding takes
+      effect after the next app restart.
     </p>
   </div>
 </section>

--- a/src/lib/components/LoggingTelemetrySettings.svelte
+++ b/src/lib/components/LoggingTelemetrySettings.svelte
@@ -1,0 +1,206 @@
+<script lang="ts">
+  import { invoke } from '@tauri-apps/api/core';
+  import { onMount } from 'svelte';
+  import { configStore } from '../stores/config.svelte';
+  import { toast } from 'svelte-sonner';
+  import { Switch } from '$components/ui/switch';
+  import { Button } from '$components/ui/button';
+  import { Input } from '$components/ui/input';
+  import { Label } from '$components/ui/label';
+  import { Badge } from '$components/ui/badge';
+
+  let isTesting = $state(false);
+  let lokiAuthDirty = $state(false);
+
+  async function saveSettings(): Promise<void> {
+    await configStore.save();
+  }
+
+  async function handleRetentionInput(event: Event): Promise<void> {
+    const input = event.target as HTMLInputElement;
+    const days = Math.max(1, Math.min(365, parseInt(input.value, 10) || 7));
+    configStore.updateLogging('localRetentionDays', days);
+  }
+
+  async function handleRetentionBlur(): Promise<void> {
+    await saveSettings();
+  }
+
+  async function handleRemoteToggle(enabled: boolean): Promise<void> {
+    configStore.updateLogging('remoteEnabled', enabled);
+    await saveSettings();
+  }
+
+  function handleLokiUrlInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    configStore.updateLogging('lokiUrl', input.value);
+  }
+
+  async function handleLokiUrlBlur(): Promise<void> {
+    await saveSettings();
+  }
+
+  function handleLokiAuthInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    lokiAuthDirty = true;
+    configStore.updateLogging('lokiAuth', input.value);
+  }
+
+  async function handleLokiAuthBlur(): Promise<void> {
+    if (!lokiAuthDirty) return;
+    lokiAuthDirty = false;
+    await saveSettings();
+  }
+
+  function handleLokiTenantInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    configStore.updateLogging('lokiTenant', input.value || null);
+  }
+
+  async function handleLokiTenantBlur(): Promise<void> {
+    await saveSettings();
+  }
+
+  async function handleTestConnection(): Promise<void> {
+    isTesting = true;
+    try {
+      await invoke('test_loki_connection');
+      toast.success('Loki connection successful');
+    } catch (e) {
+      toast.error('Loki connection failed', {
+        description: e instanceof Error ? e.message : String(e),
+      });
+    } finally {
+      isTesting = false;
+    }
+  }
+
+  onMount(async () => {
+    await configStore.load();
+  });
+</script>
+
+<!-- Section: Logging & Telemetry -->
+<section class="flex flex-col">
+  <div class="mb-3">
+    <h2 class="text-base font-semibold text-foreground m-0">Logging & Telemetry</h2>
+    <p class="text-xs text-muted-foreground m-0">
+      Local diagnostic logs and optional structured telemetry export.
+    </p>
+  </div>
+
+  <div class="flex flex-col gap-2">
+    <!-- Local logging row (always on) -->
+    <div class="flex flex-col gap-3 rounded-md border border-border bg-card p-3">
+      <div class="flex items-center justify-between gap-4">
+        <div class="flex flex-1 flex-col gap-1">
+          <span class="text-sm font-medium text-foreground">Local logging</span>
+          <span class="text-xs text-muted-foreground">
+            Logs are written to <code class="rounded bg-muted px-1 py-0.5 font-mono text-xs"
+              >~/.thoth/logs/</code
+            >
+          </span>
+        </div>
+        <Badge variant="outline" class="border-chart-2/30 bg-chart-2/10 text-chart-2 flex-shrink-0">
+          On
+        </Badge>
+      </div>
+      <div class="flex items-center gap-3">
+        <Label class="text-sm text-muted-foreground whitespace-nowrap">Keep logs for</Label>
+        <Input
+          type="number"
+          min="1"
+          max="365"
+          class="w-20 text-sm"
+          value={configStore.logging.localRetentionDays}
+          oninput={handleRetentionInput}
+          onblur={handleRetentionBlur}
+          aria-label="Log retention in days"
+        />
+        <span class="text-sm text-muted-foreground">days</span>
+      </div>
+    </div>
+
+    <!-- Forward to Loki toggle row -->
+    <div
+      class="flex items-center justify-between gap-4 rounded-md border border-border bg-card p-3"
+    >
+      <div class="flex flex-1 flex-col gap-1">
+        <span class="text-sm font-medium text-foreground">Forward telemetry to Loki</span>
+        <span class="text-xs text-muted-foreground">
+          Send structured operational events to a Loki endpoint
+        </span>
+      </div>
+      <Switch checked={configStore.logging.remoteEnabled} onCheckedChange={handleRemoteToggle} />
+    </div>
+
+    <!-- Loki connection details — shown only when remote is enabled -->
+    {#if configStore.logging.remoteEnabled}
+      <div class="flex flex-col gap-3 rounded-md border border-border bg-card p-3">
+        <!-- Loki URL -->
+        <div class="flex flex-col gap-1.5">
+          <Label class="text-sm font-medium">Loki URL</Label>
+          <Input
+            type="url"
+            class="font-mono text-sm"
+            value={configStore.logging.lokiUrl}
+            oninput={handleLokiUrlInput}
+            onblur={handleLokiUrlBlur}
+            placeholder="http://loki:3100/loki/api/v1/push"
+            aria-label="Loki push URL"
+          />
+        </div>
+
+        <!-- Bearer token -->
+        <div class="flex flex-col gap-1.5">
+          <Label class="text-sm font-medium">Bearer token</Label>
+          <Input
+            type="password"
+            class="font-mono text-sm"
+            value={configStore.logging.lokiAuth}
+            oninput={handleLokiAuthInput}
+            onblur={handleLokiAuthBlur}
+            placeholder="Bearer token (optional)"
+            autocomplete="off"
+            aria-label="Loki bearer token"
+          />
+        </div>
+
+        <!-- Tenant ID (optional) -->
+        <div class="flex flex-col gap-1.5">
+          <Label class="text-sm font-medium">
+            Tenant ID
+            <span class="ml-1 text-xs font-normal text-muted-foreground">(optional)</span>
+          </Label>
+          <Input
+            type="text"
+            class="font-mono text-sm"
+            value={configStore.logging.lokiTenant ?? ''}
+            oninput={handleLokiTenantInput}
+            onblur={handleLokiTenantBlur}
+            placeholder="X-Scope-OrgID header value"
+            aria-label="Loki tenant ID"
+          />
+        </div>
+
+        <!-- Test connection -->
+        <div class="flex items-center gap-2 mt-1">
+          <Button
+            variant="outline"
+            size="sm"
+            onclick={handleTestConnection}
+            disabled={isTesting || !configStore.logging.lokiUrl}
+          >
+            {isTesting ? 'Testing…' : 'Test connection'}
+          </Button>
+        </div>
+      </div>
+    {/if}
+
+    <!-- Privacy note -->
+    <p class="text-xs text-muted-foreground px-1">
+      Only content-free operational events are sent (timings, errors, model names) — never your
+      transcript text. Changes apply after restart.
+    </p>
+  </div>
+</section>

--- a/src/lib/components/LoggingTelemetrySettings.svelte
+++ b/src/lib/components/LoggingTelemetrySettings.svelte
@@ -9,7 +9,13 @@
   import { Label } from '$components/ui/label';
   import { Badge } from '$components/ui/badge';
 
+  // The API mask sentinel — must match LOKI_AUTH_MASK in config.rs.
+  const LOKI_AUTH_MASK = '***';
+
   let isTesting = $state(false);
+  // Tracks whether the token field has been edited in this session.
+  // When dirty, we save via set_loki_auth on blur; otherwise skip to avoid
+  // unintentionally clearing the stored token with the mask value.
   let lokiAuthDirty = $state(false);
 
   async function saveSettings(): Promise<void> {
@@ -49,7 +55,16 @@
   async function handleLokiAuthBlur(): Promise<void> {
     if (!lokiAuthDirty) return;
     lokiAuthDirty = false;
-    await saveSettings();
+    const token = configStore.logging.lokiAuth;
+    // Use the dedicated command so the preservation guard in set_config doesn't
+    // block intentional token changes (including clearing).
+    try {
+      await invoke('set_loki_auth', { token: token || null });
+    } catch (e) {
+      toast.error('Failed to save Loki token', {
+        description: e instanceof Error ? e.message : String(e),
+      });
+    }
   }
 
   function handleLokiTenantInput(event: Event): void {
@@ -64,7 +79,16 @@
   async function handleTestConnection(): Promise<void> {
     isTesting = true;
     try {
-      await invoke('test_loki_connection');
+      // Test the on-screen values directly so the user can verify before saving.
+      // If the token field shows the mask sentinel, pass empty string so Loki
+      // attempts an unauthenticated push (the real token stays server-side).
+      const authToTest =
+        configStore.logging.lokiAuth === LOKI_AUTH_MASK ? '' : configStore.logging.lokiAuth;
+      await invoke('test_loki_connection', {
+        url: configStore.logging.lokiUrl,
+        auth: authToTest,
+        tenant: configStore.logging.lokiTenant,
+      });
       toast.success('Loki connection successful');
     } catch (e) {
       toast.error('Loki connection failed', {

--- a/src/lib/components/LoggingTelemetrySettings.svelte
+++ b/src/lib/components/LoggingTelemetrySettings.svelte
@@ -21,8 +21,15 @@
   // unintentionally clearing the stored token with the mask value.
   let lokiAuthDirty = $state(false);
 
-  async function saveSettings(): Promise<void> {
-    await configStore.save();
+  // Returns true on success, false on failure (after toasting the error).
+  async function saveSettings(): Promise<boolean> {
+    const ok = await configStore.save();
+    if (!ok) {
+      toast.error('Failed to save settings', {
+        description: configStore.error ?? 'Unknown error',
+      });
+    }
+    return ok;
   }
 
   async function handleSave(): Promise<void> {
@@ -34,12 +41,14 @@
         await invoke('set_loki_auth', { token: configStore.logging.lokiAuth || null });
         lokiAuthDirty = false;
       }
-      await saveSettings();
-      toast.success('Logging settings saved', {
-        description: configStore.logging.remoteEnabled
-          ? 'Remote forwarding applies after the next app restart.'
-          : undefined,
-      });
+      const ok = await saveSettings();
+      if (ok) {
+        toast.success('Logging settings saved', {
+          description: configStore.logging.remoteEnabled
+            ? 'Remote forwarding applies after the next app restart.'
+            : undefined,
+        });
+      }
     } catch (e) {
       toast.error('Failed to save logging settings', {
         description: e instanceof Error ? e.message : String(e),
@@ -70,6 +79,11 @@
   }
 
   async function handleLokiUrlBlur(): Promise<void> {
+    // Flush the dirty token first so it goes via set_loki_auth (not the generic
+    // set_config path which the backend's preservation guard would pass through
+    // with the plaintext value). Bail if the flush failed to avoid a second toast.
+    const flushed = await handleLokiAuthBlur();
+    if (!flushed) return;
     await saveSettings();
   }
 
@@ -79,18 +93,21 @@
     configStore.updateLogging('lokiAuth', input.value);
   }
 
-  async function handleLokiAuthBlur(): Promise<void> {
-    if (!lokiAuthDirty) return;
-    lokiAuthDirty = false;
+  // Returns true if the flush succeeded (or was a no-op), false if it failed.
+  async function handleLokiAuthBlur(): Promise<boolean> {
+    if (!lokiAuthDirty) return true;
     const token = configStore.logging.lokiAuth;
     // Use the dedicated command so the preservation guard in set_config doesn't
     // block intentional token changes (including clearing).
     try {
       await invoke('set_loki_auth', { token: token || null });
+      lokiAuthDirty = false;
+      return true;
     } catch (e) {
       toast.error('Failed to save Loki token', {
         description: e instanceof Error ? e.message : String(e),
       });
+      return false;
     }
   }
 
@@ -100,6 +117,8 @@
   }
 
   async function handleLokiTenantBlur(): Promise<void> {
+    const flushed = await handleLokiAuthBlur();
+    if (!flushed) return;
     await saveSettings();
   }
 
@@ -107,10 +126,10 @@
     isTesting = true;
     try {
       // Test the on-screen values directly so the user can verify before saving.
-      // If the token field shows the mask sentinel, pass empty string so Loki
-      // attempts an unauthenticated push (the real token stays server-side).
+      // When the field shows the mask sentinel, pass null so the backend falls
+      // back to the real stored token rather than testing unauthenticated.
       const authToTest =
-        configStore.logging.lokiAuth === LOKI_AUTH_MASK ? '' : configStore.logging.lokiAuth;
+        configStore.logging.lokiAuth === LOKI_AUTH_MASK ? null : configStore.logging.lokiAuth;
       await invoke('test_loki_connection', {
         url: configStore.logging.lokiUrl,
         auth: authToTest,
@@ -127,7 +146,7 @@
   }
 
   onMount(async () => {
-    await configStore.load();
+    if (!configStore.isInitialised) await configStore.load();
   });
 </script>
 
@@ -279,7 +298,8 @@
 
   <!-- Privacy note -->
   <p class="mt-2 px-1 text-xs text-muted-foreground">
-    Only content-free operational events are sent (timings, errors, model names) — never your
-    transcript text. Remote forwarding takes effect after the next app restart.
+    Only content-free operational events are sent: timings, errors, model names, and a
+    non-identifying device ID. Transcript text is never included. Remote forwarding takes effect
+    after the next app restart.
   </p>
 </section>

--- a/src/lib/components/LoggingTelemetrySettings.svelte
+++ b/src/lib/components/LoggingTelemetrySettings.svelte
@@ -8,11 +8,14 @@
   import { Input } from '$components/ui/input';
   import { Label } from '$components/ui/label';
   import { Badge } from '$components/ui/badge';
+  import * as Tooltip from '$components/ui/tooltip';
+  import Info from '@lucide/svelte/icons/info';
 
   // The API mask sentinel — must match LOKI_AUTH_MASK in config.rs.
   const LOKI_AUTH_MASK = '***';
 
   let isTesting = $state(false);
+  let isSaving = $state(false);
   // Tracks whether the token field has been edited in this session.
   // When dirty, we save via set_loki_auth on blur; otherwise skip to avoid
   // unintentionally clearing the stored token with the mask value.
@@ -20,6 +23,30 @@
 
   async function saveSettings(): Promise<void> {
     await configStore.save();
+  }
+
+  async function handleSave(): Promise<void> {
+    isSaving = true;
+    try {
+      // Persist the token via the dedicated command (bypasses the preservation
+      // guard) when edited, then save the rest of the config.
+      if (lokiAuthDirty) {
+        await invoke('set_loki_auth', { token: configStore.logging.lokiAuth || null });
+        lokiAuthDirty = false;
+      }
+      await saveSettings();
+      toast.success('Logging settings saved', {
+        description: configStore.logging.remoteEnabled
+          ? 'Remote forwarding applies after the next app restart.'
+          : undefined,
+      });
+    } catch (e) {
+      toast.error('Failed to save logging settings', {
+        description: e instanceof Error ? e.message : String(e),
+      });
+    } finally {
+      isSaving = false;
+    }
   }
 
   async function handleRetentionInput(event: Event): Promise<void> {
@@ -113,9 +140,11 @@
     </p>
   </div>
 
-  <div class="flex flex-col gap-2">
-    <!-- Local logging row (always on) -->
-    <div class="flex flex-col gap-3 rounded-md border border-border bg-card p-3">
+  <!-- One consolidated card: local logging, remote toggle, connection details,
+       and the test/save actions, separated by internal dividers. -->
+  <div class="divide-y divide-border rounded-md border border-border bg-card">
+    <!-- Local logging (always on) -->
+    <div class="flex flex-col gap-3 p-3">
       <div class="flex items-center justify-between gap-4">
         <div class="flex flex-1 flex-col gap-1">
           <span class="text-sm font-medium text-foreground">Local logging</span>
@@ -145,10 +174,8 @@
       </div>
     </div>
 
-    <!-- Forward to Loki toggle row -->
-    <div
-      class="flex items-center justify-between gap-4 rounded-md border border-border bg-card p-3"
-    >
+    <!-- Forward to Loki -->
+    <div class="flex items-center justify-between gap-4 p-3">
       <div class="flex flex-1 flex-col gap-1">
         <span class="text-sm font-medium text-foreground">Forward telemetry to Loki</span>
         <span class="text-xs text-muted-foreground">
@@ -160,7 +187,7 @@
 
     <!-- Loki connection details — shown only when remote is enabled -->
     {#if configStore.logging.remoteEnabled}
-      <div class="flex flex-col gap-3 rounded-md border border-border bg-card p-3">
+      <div class="flex flex-col gap-3 p-3">
         <!-- Loki URL -->
         <div class="flex flex-col gap-1.5">
           <Label class="text-sm font-medium">Loki URL</Label>
@@ -196,42 +223,63 @@
           </p>
         </div>
 
-        <!-- Tenant ID (optional) -->
+        <!-- Tenant ID (optional, with explanation) -->
         <div class="flex flex-col gap-1.5">
-          <Label class="text-sm font-medium">
-            Tenant ID
-            <span class="ml-1 text-xs font-normal text-muted-foreground">(optional)</span>
-          </Label>
+          <div class="flex items-center gap-1.5">
+            <Label class="text-sm font-medium">Tenant ID</Label>
+            <span class="text-xs font-normal text-muted-foreground">(optional)</span>
+            <Tooltip.Provider delayDuration={150}>
+              <Tooltip.Root>
+                <Tooltip.Trigger
+                  class="text-muted-foreground transition-colors hover:text-foreground"
+                  aria-label="What is the Tenant ID?"
+                >
+                  <Info class="h-3.5 w-3.5" />
+                </Tooltip.Trigger>
+                <Tooltip.Content class="max-w-xs">
+                  <p class="text-xs leading-snug">
+                    Only for multi-tenant Loki (e.g. Grafana Cloud): sets the
+                    <span class="font-mono">X-Scope-OrgID</span> header to select a tenant. Leave it blank
+                    for a single-tenant instance such as a self-hosted Loki.
+                  </p>
+                </Tooltip.Content>
+              </Tooltip.Root>
+            </Tooltip.Provider>
+          </div>
           <Input
             type="text"
             class="font-mono text-sm"
             value={configStore.logging.lokiTenant ?? ''}
             oninput={handleLokiTenantInput}
             onblur={handleLokiTenantBlur}
-            placeholder="X-Scope-OrgID header value"
+            placeholder="Leave blank unless multi-tenant"
             aria-label="Loki tenant ID"
           />
-        </div>
-
-        <!-- Test connection -->
-        <div class="flex items-center gap-2 mt-1">
-          <Button
-            variant="outline"
-            size="sm"
-            onclick={handleTestConnection}
-            disabled={isTesting || !configStore.logging.lokiUrl}
-          >
-            {isTesting ? 'Testing…' : 'Test connection'}
-          </Button>
         </div>
       </div>
     {/if}
 
-    <!-- Privacy + save note -->
-    <p class="text-xs text-muted-foreground px-1">
-      Settings save automatically — there's no save button. Only content-free operational events are
-      sent (timings, errors, model names) — never your transcript text. Remote forwarding takes
-      effect after the next app restart.
-    </p>
+    <!-- Actions: test + save, co-located -->
+    <div class="flex items-center gap-2 p-3">
+      {#if configStore.logging.remoteEnabled}
+        <Button
+          variant="outline"
+          size="sm"
+          onclick={handleTestConnection}
+          disabled={isTesting || !configStore.logging.lokiUrl}
+        >
+          {isTesting ? 'Testing…' : 'Test connection'}
+        </Button>
+      {/if}
+      <Button size="sm" onclick={handleSave} disabled={isSaving}>
+        {isSaving ? 'Saving…' : 'Save'}
+      </Button>
+    </div>
   </div>
+
+  <!-- Privacy note -->
+  <p class="mt-2 px-1 text-xs text-muted-foreground">
+    Only content-free operational events are sent (timings, errors, model names) — never your
+    transcript text. Remote forwarding takes effect after the next app restart.
+  </p>
 </section>

--- a/src/lib/dev/thoth-mock-data.ts
+++ b/src/lib/dev/thoth-mock-data.ts
@@ -244,7 +244,7 @@ const MOCK_CLIPBOARD_SETTINGS = {
 // Insights mock data
 // ---------------------------------------------------------------------------
 
-/** Build ~90 days of realistic activity ending today */
+/** Build ~14 months of realistic activity ending today, so heatmap month labels span multiple months */
 function buildMockActivity(): Array<{ day: string; count: number; words: number }> {
   const activity = [];
   const today = new Date();
@@ -255,7 +255,8 @@ function buildMockActivity(): Array<{ day: string; count: number; words: number 
     return (seed >>> 0) / 0xffffffff;
   };
 
-  for (let i = 89; i >= 0; i--) {
+  // 365 days = one full year of data so all month labels appear
+  for (let i = 364; i >= 0; i--) {
     const d = new Date(today);
     d.setDate(d.getDate() - i);
     const day = d.toISOString().slice(0, 10);
@@ -289,21 +290,21 @@ const MOCK_INSIGHTS_DATA = {
   longestStreak: 31,
   throughput: [
     {
-      name: 'FluidAudio',
+      name: 'fluidaudio-parakeet-tdt-coreml',
       count: 1200,
       avgAudioDuration: 8.2,
       avgProcessingTime: 0.12,
       speedFactor: 67,
     },
     {
-      name: 'Whisper',
+      name: 'ggml-large-v3-turbo',
       count: 580,
       avgAudioDuration: 11.4,
       avgProcessingTime: 0.67,
       speedFactor: 17,
     },
     {
-      name: 'Parakeet',
+      name: 'parakeet-tdt-1.1',
       count: 62,
       avgAudioDuration: 6.1,
       avgProcessingTime: 1.05,
@@ -312,9 +313,9 @@ const MOCK_INSIGHTS_DATA = {
   ],
   modelUsage: {
     backendCounts: [
-      { name: 'FluidAudio (Parakeet v3)', count: 1200 },
-      { name: 'Whisper Small', count: 580 },
-      { name: 'Parakeet TDT v3', count: 62 },
+      { name: 'fluidaudio-parakeet-tdt-coreml', count: 1200 },
+      { name: 'ggml-large-v3-turbo', count: 580 },
+      { name: 'parakeet-tdt-1.1', count: 62 },
     ],
     enhancementPrompts: [
       { prompt: 'Fix grammar and punctuation', count: 210 },

--- a/src/lib/dev/thoth-mock-data.ts
+++ b/src/lib/dev/thoth-mock-data.ts
@@ -60,6 +60,15 @@ const MOCK_CONFIG = {
     api_port: 8765,
     mcp_enabled: false,
   },
+  logging: {
+    local_retention_days: 7,
+    remote_enabled: false,
+    loki_url: '',
+    loki_auth: '',
+    loki_tenant: null,
+    loki_labels: [] as [string, string][],
+    telemetry_level: 'info',
+  },
 };
 
 const MOCK_MODELS = [
@@ -577,6 +586,16 @@ export const thothMockCommands: CommandMap = {
   remove_quarantine: () => undefined,
   start_audio_preview: () => undefined,
   stop_audio_preview: () => undefined,
+
+  // -- Logging & Telemetry --
+  test_loki_connection: (args) => {
+    const url = (args as { url?: string } | undefined)?.url ?? '';
+    // Simulate failure for obviously-bogus URLs (empty or localhost placeholder)
+    if (!url || url === 'http://loki:3100/loki/api/v1/push') {
+      throw new Error('Connection refused — is Loki reachable?');
+    }
+    return undefined;
+  },
 
   // -- Integrations (Local Control API + MCP server) --
   get_integrations_status: () => ({

--- a/src/lib/dev/thoth-mock-data.ts
+++ b/src/lib/dev/thoth-mock-data.ts
@@ -232,6 +232,153 @@ const MOCK_CLIPBOARD_SETTINGS = {
 };
 
 // ---------------------------------------------------------------------------
+// Insights mock data
+// ---------------------------------------------------------------------------
+
+/** Build ~90 days of realistic activity ending today */
+function buildMockActivity(): Array<{ day: string; count: number; words: number }> {
+  const activity = [];
+  const today = new Date();
+  // Seed the RNG deterministically so the heatmap looks the same each load
+  let seed = 42;
+  const rand = () => {
+    seed = (seed * 1664525 + 1013904223) & 0xffffffff;
+    return (seed >>> 0) / 0xffffffff;
+  };
+
+  for (let i = 89; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - i);
+    const day = d.toISOString().slice(0, 10);
+    // Realistic pattern: weekdays heavier, occasional weekends, some gaps
+    const dow = d.getDay();
+    const isWeekend = dow === 0 || dow === 6;
+    const base = isWeekend ? 2 : 8;
+    const r = rand();
+    if (r < 0.15) {
+      // Day off
+      continue;
+    }
+    const count = Math.round(base * r * 2 + 1);
+    const words = count * Math.round(30 + rand() * 80);
+    activity.push({ day, count, words });
+  }
+  return activity;
+}
+
+const MOCK_INSIGHTS_DATA = {
+  totals: {
+    totalCount: 1842,
+    totalAudioSeconds: 28560,
+    totalWords: 183400,
+    enhancedCount: 312,
+    typingTimeSavedSeconds: 275100, // 183400 words / 40 wpm * 60s
+    firstRecordingAt: new Date(Date.now() - 90 * 24 * 3600 * 1000).toISOString(),
+  },
+  activity: buildMockActivity(),
+  currentStreak: 14,
+  longestStreak: 31,
+  throughput: [
+    {
+      name: 'FluidAudio',
+      count: 1200,
+      avgAudioDuration: 8.2,
+      avgProcessingTime: 0.12,
+      speedFactor: 67,
+    },
+    {
+      name: 'Whisper',
+      count: 580,
+      avgAudioDuration: 11.4,
+      avgProcessingTime: 0.67,
+      speedFactor: 17,
+    },
+    {
+      name: 'Parakeet',
+      count: 62,
+      avgAudioDuration: 6.1,
+      avgProcessingTime: 1.05,
+      speedFactor: 5.8,
+    },
+  ],
+  modelUsage: {
+    backendCounts: [
+      { name: 'FluidAudio (Parakeet v3)', count: 1200 },
+      { name: 'Whisper Small', count: 580 },
+      { name: 'Parakeet TDT v3', count: 62 },
+    ],
+    enhancementPrompts: [
+      { prompt: 'Fix grammar and punctuation', count: 210 },
+      { prompt: 'Summarise', count: 102 },
+    ],
+    enhancedPct: 17,
+  },
+  lengthHistogram: [
+    { bucketLabel: '0–5s', count: 412 },
+    { bucketLabel: '5–15s', count: 680 },
+    { bucketLabel: '15–30s', count: 420 },
+    { bucketLabel: '30–60s', count: 210 },
+    { bucketLabel: '1–2m', count: 88 },
+    { bucketLabel: '2m+', count: 32 },
+  ],
+  timeOfDay: [
+    2, 0, 0, 0, 0, 1, 4, 18, 72, 95, 112, 98, 85, 76, 88, 102, 94, 68, 42, 28, 14, 8, 4, 2,
+  ],
+  storage: {
+    recordingsBytes: 412 * 1024 * 1024,
+    modelsBytes: 155 * 1024 * 1024,
+    dbBytes: 2.4 * 1024 * 1024,
+    totalBytes: (412 + 155 + 2.4) * 1024 * 1024,
+    oldestRecordingAt: new Date(Date.now() - 90 * 24 * 3600 * 1000).toISOString(),
+  },
+};
+
+// Realistic cruft: low-density recordings (chars/sec well below the ~1.0
+// threshold) — a silent forgotten-toggle and two silence-hallucinations.
+const MOCK_CRUFT_CANDIDATES = [
+  {
+    id: 'cruft-1',
+    createdAt: new Date(Date.now() - 5 * 24 * 3600 * 1000).toISOString(),
+    textPreview: '',
+    durationSeconds: 47.2,
+    density: 0.0,
+    audioPath: '/Users/dev/.thoth/Recordings/thoth_recording_20240617_050312.wav',
+    fileBytes: 1510400,
+    rms: 0.015,
+  },
+  {
+    id: 'cruft-2',
+    createdAt: new Date(Date.now() - 3 * 24 * 3600 * 1000).toISOString(),
+    textPreview: 'Thank you.',
+    durationSeconds: 16.4,
+    density: 0.6,
+    audioPath: '/Users/dev/.thoth/Recordings/thoth_recording_20240619_091033.wav',
+    fileBytes: 524800,
+    rms: 0.041,
+  },
+  {
+    id: 'cruft-3',
+    createdAt: new Date(Date.now() - 1 * 24 * 3600 * 1000).toISOString(),
+    textPreview: 'Okay.',
+    durationSeconds: 23.1,
+    density: 0.2,
+    audioPath: '/Users/dev/.thoth/Recordings/thoth_recording_20240621_152244.wav',
+    fileBytes: 739200,
+    rms: null,
+  },
+];
+
+const MOCK_TRASH_ENTRIES: Array<{
+  id: string;
+  textPreview: string;
+  createdAt: string;
+  deletedAt: string;
+  durationSeconds: number;
+  fileBytes: number;
+  audioMoved: boolean;
+}> = [];
+
+// ---------------------------------------------------------------------------
 // Command map
 // ---------------------------------------------------------------------------
 
@@ -277,6 +424,51 @@ export const thothMockCommands: CommandMap = {
 
   // -- Storage pane --
   get_storage_usage: () => MOCK_STORAGE_USAGE,
+
+  // -- Insights pane --
+  get_insights: () => MOCK_INSIGHTS_DATA,
+  get_cruft_candidates: () => MOCK_CRUFT_CANDIDATES,
+  quarantine_recordings: (args) => {
+    const ids = (args as { ids?: string[] } | undefined)?.ids ?? [];
+    // Move matched candidates into the mock trash
+    const moved = MOCK_CRUFT_CANDIDATES.filter((c) => ids.includes(c.id));
+    for (const m of moved) {
+      MOCK_TRASH_ENTRIES.push({
+        id: m.id,
+        textPreview: m.textPreview,
+        createdAt: m.createdAt,
+        deletedAt: new Date().toISOString(),
+        durationSeconds: m.durationSeconds,
+        fileBytes: m.fileBytes,
+        audioMoved: true,
+      });
+      const idx = MOCK_CRUFT_CANDIDATES.findIndex((c) => c.id === m.id);
+      if (idx !== -1) MOCK_CRUFT_CANDIDATES.splice(idx, 1);
+    }
+    return moved.length;
+  },
+  restore_recordings: (args) => {
+    const ids = (args as { ids?: string[] } | undefined)?.ids ?? [];
+    ids.forEach((id) => {
+      const idx = MOCK_TRASH_ENTRIES.findIndex((e) => e.id === id);
+      if (idx !== -1) MOCK_TRASH_ENTRIES.splice(idx, 1);
+    });
+    return ids.length;
+  },
+  purge_trash: (args) => {
+    const ids = (args as { ids?: string[] } | undefined)?.ids;
+    if (!ids || ids.length === 0) {
+      MOCK_TRASH_ENTRIES.splice(0, MOCK_TRASH_ENTRIES.length);
+    } else {
+      ids.forEach((id) => {
+        const idx = MOCK_TRASH_ENTRIES.findIndex((e) => e.id === id);
+        if (idx !== -1) MOCK_TRASH_ENTRIES.splice(idx, 1);
+      });
+    }
+    return undefined;
+  },
+  list_trash: () => [...MOCK_TRASH_ENTRIES],
+  compute_audio_rms: () => 0.18,
 
   // -- Permissions pane --
   check_accessibility: () => true,

--- a/src/lib/dev/thoth-mock-data.ts
+++ b/src/lib/dev/thoth-mock-data.ts
@@ -259,7 +259,11 @@ function buildMockActivity(): Array<{ day: string; count: number; words: number 
   for (let i = 364; i >= 0; i--) {
     const d = new Date(today);
     d.setDate(d.getDate() - i);
-    const day = d.toISOString().slice(0, 10);
+    const day = [
+      d.getFullYear(),
+      String(d.getMonth() + 1).padStart(2, '0'),
+      String(d.getDate()).padStart(2, '0'),
+    ].join('-');
     // Realistic pattern: weekdays heavier, occasional weekends, some gaps
     const dow = d.getDay();
     const isWeekend = dow === 0 || dow === 6;
@@ -383,7 +387,7 @@ const MOCK_TRASH_ENTRIES: Array<{
   textPreview: string;
   createdAt: string;
   deletedAt: string;
-  durationSeconds: number;
+  durationSeconds: number | null;
   fileBytes: number;
   audioMoved: boolean;
 }> = [];
@@ -478,7 +482,6 @@ export const thothMockCommands: CommandMap = {
     return undefined;
   },
   list_trash: () => [...MOCK_TRASH_ENTRIES],
-  compute_audio_rms: () => 0.18,
 
   // -- Permissions pane --
   check_accessibility: () => true,

--- a/src/lib/stores/config.svelte.ts
+++ b/src/lib/stores/config.svelte.ts
@@ -70,6 +70,24 @@ export interface IntegrationsConfig {
   mcpEnabled: boolean;
 }
 
+/** Logging and telemetry configuration */
+export interface LoggingConfig {
+  /** Local log retention in days */
+  localRetentionDays: number;
+  /** Whether to forward telemetry to a remote Loki instance */
+  remoteEnabled: boolean;
+  /** Loki push URL */
+  lokiUrl: string;
+  /** Loki bearer token (secret) */
+  lokiAuth: string;
+  /** Optional Loki tenant ID (X-Scope-OrgID header) */
+  lokiTenant: string | null;
+  /** Extra static labels as [key, value] pairs */
+  lokiLabels: [string, string][];
+  /** Telemetry level: "error", "warn", "info", "debug" */
+  telemetryLevel: string;
+}
+
 /** AI enhancement configuration */
 export interface EnhancementConfig {
   /** Whether AI enhancement is enabled */
@@ -149,6 +167,8 @@ export interface Config {
   recorder: RecorderConfig;
   /** Integrations settings */
   integrations: IntegrationsConfig;
+  /** Logging and telemetry settings */
+  logging: LoggingConfig;
 }
 
 /** Raw config from backend (snake_case fields) */
@@ -207,6 +227,15 @@ interface ConfigRaw {
     api_enabled: boolean;
     api_port: number;
     mcp_enabled: boolean;
+  };
+  logging?: {
+    local_retention_days: number;
+    remote_enabled: boolean;
+    loki_url: string;
+    loki_auth: string;
+    loki_tenant: string | null;
+    loki_labels: [string, string][];
+    telemetry_level: string;
   };
 }
 
@@ -267,6 +296,15 @@ function parseConfig(raw: ConfigRaw): Config {
       apiEnabled: raw.integrations?.api_enabled ?? false,
       apiPort: raw.integrations?.api_port ?? 8765,
       mcpEnabled: raw.integrations?.mcp_enabled ?? false,
+    },
+    logging: {
+      localRetentionDays: raw.logging?.local_retention_days ?? 7,
+      remoteEnabled: raw.logging?.remote_enabled ?? false,
+      lokiUrl: raw.logging?.loki_url ?? '',
+      lokiAuth: raw.logging?.loki_auth ?? '',
+      lokiTenant: raw.logging?.loki_tenant ?? null,
+      lokiLabels: raw.logging?.loki_labels ?? [],
+      telemetryLevel: raw.logging?.telemetry_level ?? 'info',
     },
   };
 }
@@ -329,6 +367,15 @@ function serialiseConfig(config: Config): ConfigRaw {
       api_port: config.integrations.apiPort,
       mcp_enabled: config.integrations.mcpEnabled,
     },
+    logging: {
+      local_retention_days: config.logging.localRetentionDays,
+      remote_enabled: config.logging.remoteEnabled,
+      loki_url: config.logging.lokiUrl,
+      loki_auth: config.logging.lokiAuth,
+      loki_tenant: config.logging.lokiTenant,
+      loki_labels: config.logging.lokiLabels,
+      telemetry_level: config.logging.telemetryLevel,
+    },
   };
 }
 
@@ -389,6 +436,15 @@ function getDefaultConfig(): Config {
       apiEnabled: false,
       apiPort: 8765,
       mcpEnabled: false,
+    },
+    logging: {
+      localRetentionDays: 7,
+      remoteEnabled: false,
+      lokiUrl: '',
+      lokiAuth: '',
+      lokiTenant: null,
+      lokiLabels: [],
+      telemetryLevel: 'info',
     },
   };
 }
@@ -536,6 +592,13 @@ function createConfigStore() {
   }
 
   /**
+   * Update a specific logging config field
+   */
+  function updateLogging<K extends keyof LoggingConfig>(key: K, value: LoggingConfig[K]): void {
+    config.logging[key] = value;
+  }
+
+  /**
    * Set or clear the enhancement API key via the dedicated backend command.
    *
    * This is the only correct way to change the API key. The generic save()
@@ -601,6 +664,9 @@ function createConfigStore() {
     get integrations() {
       return config.integrations;
     },
+    get logging() {
+      return config.logging;
+    },
 
     // Actions
     load,
@@ -614,6 +680,7 @@ function createConfigStore() {
     updateGeneral,
     updateRecorder,
     updateIntegrations,
+    updateLogging,
     setEnhancementApiKey,
     clearError,
   };

--- a/src/lib/utils/model-name.ts
+++ b/src/lib/utils/model-name.ts
@@ -1,0 +1,73 @@
+/**
+ * Friendly display names for transcription model IDs.
+ *
+ * The canonical source is models/manifest.json (fetched at runtime via
+ * fetch_model_manifest). This static map covers the IDs that appear in
+ * historical transcription records and the insights dashboard — the manifest
+ * is not available at render time for those records.
+ *
+ * Fallback: stripModelId() cleans up any unknown ID into a readable label.
+ */
+
+const MODEL_DISPLAY_NAMES: Record<string, string> = {
+  // Whisper ggml models (from manifest.json)
+  'ggml-large-v3-turbo': 'Whisper Large v3 Turbo',
+  'ggml-medium.en': 'Whisper Medium (English)',
+  'ggml-small.en': 'Whisper Small (English)',
+  // Parakeet sherpa-rs models
+  'parakeet-tdt-0.6b-v2-int8': 'Parakeet TDT v2',
+  'parakeet-tdt-0.6b-v3-int8': 'Parakeet TDT v3',
+  // FluidAudio CoreML model
+  'fluidaudio-parakeet-tdt-coreml': 'Parakeet TDT v3 (ANE)',
+  // Legacy / alternate spellings that may appear in old records
+  'parakeet-tdt-1.1': 'Parakeet TDT v1.1',
+  fluidaudio: 'Parakeet TDT v3 (ANE)',
+  whisper: 'Whisper',
+  parakeet: 'Parakeet TDT',
+};
+
+/**
+ * Produce a readable label for a model ID that is not in the map.
+ * Strips vendor prefixes, file extensions, and cleans up separators.
+ */
+function stripModelId(id: string): string {
+  return (
+    id
+      // drop ggml- prefix
+      .replace(/^ggml-/i, '')
+      // drop .bin extension
+      .replace(/\.bin$/i, '')
+      // drop fluidaudio- prefix
+      .replace(/^fluidaudio-/i, '')
+      // normalise separators to spaces
+      .replace(/[-_.]/g, ' ')
+      // title-case each word
+      .split(' ')
+      .filter(Boolean)
+      .map((w) => {
+        // Keep known abbreviations uppercase
+        if (/^(tdt|ane|coreml|v\d|int\d|en|gpu)$/i.test(w)) {
+          // Preserve "v3", "int8" casing; uppercase short all-alpha tokens
+          if (/^v\d/i.test(w)) return w.toLowerCase();
+          if (/^int\d/i.test(w)) return w.toLowerCase();
+          return w.toUpperCase();
+        }
+        return w.charAt(0).toUpperCase() + w.slice(1).toLowerCase();
+      })
+      .join(' ')
+  );
+}
+
+/** Return a human-friendly display name for a transcription model ID. */
+export function friendlyModelName(id: string): string {
+  if (!id) return 'Unknown';
+  const direct = MODEL_DISPLAY_NAMES[id];
+  if (direct) return direct;
+  // Case-insensitive lookup
+  const lower = id.toLowerCase();
+  const caseInsensitive = Object.entries(MODEL_DISPLAY_NAMES).find(
+    ([k]) => k.toLowerCase() === lower
+  );
+  if (caseInsensitive) return caseInsensitive[1];
+  return stripModelId(id);
+}

--- a/src/lib/windows/Settings.svelte
+++ b/src/lib/windows/Settings.svelte
@@ -20,6 +20,7 @@
   import FileText from '@lucide/svelte/icons/file-text';
   import HardDrive from '@lucide/svelte/icons/hard-drive';
   import Plug from '@lucide/svelte/icons/plug';
+  import BarChart3 from '@lucide/svelte/icons/bar-chart-3';
   import Info from '@lucide/svelte/icons/info';
   import AIEnhancementSettings from '../components/AIEnhancementSettings.svelte';
   import AudioDeviceSelector from '../components/AudioDeviceSelector.svelte';
@@ -28,6 +29,7 @@
   import StoragePane from '../components/StoragePane.svelte';
   import IntegrationsSettings from '../components/IntegrationsSettings.svelte';
   import HistoryPane from '../components/HistoryPane.svelte';
+  import InsightsPane from '../components/InsightsPane.svelte';
   import ModelManager from '../components/ModelManager.svelte';
   import TranscribePane from '../components/TranscribePane.svelte';
   import OverviewPane from '../components/OverviewPane.svelte';
@@ -62,6 +64,7 @@
   /** Available settings panes matching Swift app */
   const panes: SettingsPane[] = [
     { id: 'overview', title: 'Overview', icon: LayoutDashboard },
+    { id: 'insights', title: 'Insights', icon: BarChart3 },
     { id: 'recording', title: 'Recording', icon: Mic },
     { id: 'models', title: 'Models', icon: Cpu },
     { id: 'ai', title: 'AI Enhancement', icon: Sparkles },
@@ -308,13 +311,19 @@
         <div class="pane">
           <OverviewPane onNavigate={(paneId) => (activePane = paneId)} />
         </div>
+      {:else if activePane === 'insights'}
+        <div class="pane">
+          <InsightsPane />
+        </div>
       {:else if activePane === 'recording'}
         <div class="pane">
           <!-- Audio Input Section -->
           <section class="flex flex-col">
             <div class="mb-3">
               <h2 class="text-base font-semibold text-foreground m-0">Audio Input</h2>
-              <p class="text-xs text-muted-foreground m-0">Choose how Thoth selects your audio input device</p>
+              <p class="text-xs text-muted-foreground m-0">
+                Choose how Thoth selects your audio input device
+              </p>
             </div>
             <div class="flex flex-col gap-2">
               <AudioDeviceSelector />
@@ -325,19 +334,22 @@
           <section class="flex flex-col">
             <div class="mb-3">
               <h2 class="text-base font-semibold text-foreground m-0">Shortcuts</h2>
-              <p class="text-xs text-muted-foreground m-0">Tap to start recording, tap again to stop.</p>
+              <p class="text-xs text-muted-foreground m-0">
+                Tap to start recording, tap again to stop.
+              </p>
             </div>
             <div class="flex flex-col gap-2">
               {#if !shortcutsStore.isLoading}
                 <div class="shortcuts-list">
                   {#each allShortcuts as shortcut, i (shortcut.id)}
-                    <div class="flex items-center justify-between gap-4 rounded-md border border-border bg-card p-3">
+                    <div
+                      class="flex items-center justify-between gap-4 rounded-md border border-border bg-card p-3"
+                    >
                       <div class="flex flex-1 flex-col gap-1">
-                        <span class="text-sm font-medium text-foreground">{shortcut.description}</span>
-                        <span
-                          class="text-xs shortcut-status"
-                          class:enabled={shortcut.isEnabled}
+                        <span class="text-sm font-medium text-foreground"
+                          >{shortcut.description}</span
                         >
+                        <span class="text-xs shortcut-status" class:enabled={shortcut.isEnabled}>
                           {shortcut.isEnabled ? 'Active' : 'Inactive'}
                         </span>
                       </div>
@@ -361,10 +373,14 @@
           <section class="flex flex-col">
             <div class="mb-3">
               <h2 class="text-base font-semibold text-foreground m-0">Recording Behaviour</h2>
-              <p class="text-xs text-muted-foreground m-0">Audio and clipboard handling during transcription</p>
+              <p class="text-xs text-muted-foreground m-0">
+                Audio and clipboard handling during transcription
+              </p>
             </div>
             <div class="flex flex-col gap-2">
-              <div class="flex items-center justify-between gap-4 rounded-md border border-border bg-card p-3">
+              <div
+                class="flex items-center justify-between gap-4 rounded-md border border-border bg-card p-3"
+              >
                 <div class="flex flex-1 flex-col gap-1">
                   <span class="text-sm font-medium text-foreground">Sound Feedback</span>
                   <span class="text-xs text-muted-foreground"
@@ -378,10 +394,14 @@
                 />
               </div>
               <div class="row-separator"></div>
-              <div class="flex items-center justify-between gap-4 rounded-md border border-border bg-card p-3">
+              <div
+                class="flex items-center justify-between gap-4 rounded-md border border-border bg-card p-3"
+              >
                 <div class="flex flex-1 flex-col gap-1">
                   <span class="text-sm font-medium text-foreground">Recording Indicator</span>
-                  <span class="text-xs text-muted-foreground">Show floating indicator during recording</span>
+                  <span class="text-xs text-muted-foreground"
+                    >Show floating indicator during recording</span
+                  >
                 </div>
                 <Switch
                   checked={configStore.general.showRecordingIndicator}
@@ -405,7 +425,9 @@
               </div>
               {#if configStore.general.showRecordingIndicator}
                 <div class="row-separator"></div>
-                <div class="flex items-center justify-between gap-4 rounded-md border border-border bg-card p-3">
+                <div
+                  class="flex items-center justify-between gap-4 rounded-md border border-border bg-card p-3"
+                >
                   <div class="flex flex-1 flex-col gap-1">
                     <span class="text-sm font-medium text-foreground">Indicator Style</span>
                     <span class="text-xs text-muted-foreground"
@@ -516,14 +538,7 @@
                     <div class="mode-preview">
                       <svg viewBox="0 0 80 52" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <!-- Pill shape -->
-                        <rect
-                          x="8"
-                          y="16"
-                          width="64"
-                          height="20"
-                          rx="10"
-                          fill="var(--primary)"
-                        />
+                        <rect x="8" y="16" width="64" height="20" rx="10" fill="var(--primary)" />
                         <!-- Mic icon on left side -->
                         <rect x="17" y="22" width="4" height="6" rx="2" fill="white" />
                         <path
@@ -613,7 +628,9 @@
           <section class="flex flex-col">
             <div class="mb-3">
               <h2 class="text-base font-semibold text-foreground m-0">Speech Recognition</h2>
-              <p class="text-xs text-muted-foreground m-0">Local models for transcribing speech to text</p>
+              <p class="text-xs text-muted-foreground m-0">
+                Local models for transcribing speech to text
+              </p>
             </div>
             <div class="flex flex-col gap-2">
               <ModelManager />
@@ -665,7 +682,9 @@
           <section class="flex flex-col">
             <div class="mb-3">
               <h2 class="text-base font-semibold text-foreground m-0">Output Filtering</h2>
-              <p class="text-xs text-muted-foreground m-0">Configure how transcription output is processed</p>
+              <p class="text-xs text-muted-foreground m-0">
+                Configure how transcription output is processed
+              </p>
             </div>
             <div class="flex flex-col gap-2">
               <FilterSettings

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,8 +55,12 @@ export default defineConfig(async () => ({
         }
       : undefined,
     watch: {
-      // 3. tell Vite to ignore watching `src-tauri`
-      ignored: ['**/src-tauri/**'],
+      // 3. ignore the Rust backend, plus directories that hold duplicate copies
+      //    of the frontend source: stale git worktrees under `.claude/`, the
+      //    direnv/flake source snapshot under `.direnv/`, and `.git`. Watching
+      //    those makes Vite fire spurious full page reloads (their duplicate
+      //    `src/app.html` etc. change), which reset the in-app navigation.
+      ignored: ['**/src-tauri/**', '**/.claude/**', '**/.direnv/**', '**/.git/**'],
     },
   },
 }));


### PR DESCRIPTION
## Summary

Implements the Insights dashboard (#90) and an opt-in, content-free observability export to Grafana Loki, plus a small window widen. Backend + frontend, verified locally; **awaiting review — not merged.**

## What's in it (7 commits)

- **Window**: main window 900→1100 with a min-size floor (the dashboard's two-column charts need room).
- **Insights backend**: `get_insights` (totals, daily activity + streaks, throughput, model/enhancement usage, length & time-of-day, storage), `get_cruft_candidates` (density-flagged + lazy per-candidate RMS), `compute_audio_rms`. SQL-side aggregation; activity/time buckets use `localtime` so they reflect the user's day (created_at is stored UTC).
- **Reversible Trash**: `~/.thoth/Trash/` quarantine (v3 migration) backing the cruft finder so deletes are reversible, never permanent (`quarantine`/`restore`/`purge`/`list`, 30-day auto-purge, ref-count guard). Fixed a restore bug that would have stranded audio.
- **Observability backend**: layered tracing (always-on local file → now a daily rolling appender with retention) + optional `tracing-loki` layer filtered to a `telemetry` target so only content-free events ship (timings, speed factors, lifecycle, errors — never transcript text). `LoggingConfig` with a redacted auth token; `test_loki_connection`. TLS stays on rustls+ring (no aws-lc).
- **Insights frontend**: new Insights pane (hero cards, amber contribution heatmap, throughput/usage/length/time-of-day charts, cruft finder with reversible Trash, storage). Verified in a browser via the dev IPC mock.
- **Logging settings UI**: a Logging & Telemetry card in Integrations (retention + opt-in Loki forward toggle/URL/token/tenant/test).
- **Backfill script**: `scripts/loki_backfill.py` — ships a curated, content-free subset of the existing local log to Loki; `--dry-run` verified 169530 lines, no transcript content.

## Decisions to flag (yours to override)

- **Charts use CSS bars, not LayerChart.** Stable layerchart 1.x isn't Svelte-5 compatible (only a `2.0.0-next` prerelease is); not worth a prerelease for bar charts + a custom-CSS heatmap. The charting rule permits a clean CSS fallback (browser layout, no hand-placed coordinates). Dead deps removed.
- **Existing History/storage deletes are NOT yet routed through Trash** — deliberate, to keep the diff reviewable. Worth a follow-up so all deletes are reversible.
- **Loki forwarding applies on restart** (built at startup from config).
- Local logging is **always on**; remote is an additive opt-in (never either/or), off by default.

## Verification

- `cargo fmt --check` clean; `cargo clippy --all-targets -D warnings` clean; `pnpm check` clean (3 pre-existing warnings).
- Both UI surfaces driven and screenshotted in a real browser.
- Rust unit tests (insights/trash/config) run in **CI** — the local Nix dev shell can't link the test binary (pre-existing Swift-toolchain mismatch, unrelated to this work).

## Before merge / at the pause (needs you)

1. Live-test the rebuilt app (mic/accessibility TCC will reset on reinstall).
2. Loki backfill: provide the Loki push endpoint + token, relax `reject_old_samples_max_age` on the Loki instance for the run, then `python3 scripts/loki_backfill.py`.
3. Merge + cut a CalVer release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)